### PR TITLE
[Add] Getting a NestedParameters as a flat list function

### DIFF
--- a/CDP4Common.Tests/Helpers/NestedElementTreeGeneratorTestFixtre.cs
+++ b/CDP4Common.Tests/Helpers/NestedElementTreeGeneratorTestFixtre.cs
@@ -251,28 +251,5 @@ namespace CDP4Common.Tests.Helpers
 
             Assert.IsNotEmpty(flatNestedParameters);
         }
-
-        [Test]
-        public void Verify_that_the_function_does_not_include_parameters_from_excluded_ElementUsages()
-        {
-            var option = this.iteration.Option.Single(x => x.ShortName == "OPT_A");
-            var flatNestedParameters = this.nestedElementTreeGenerator.GetNestedParameters(option, this.domainOfExpertise);
-
-            foreach (var nestedParameter in flatNestedParameters)
-            {
-                Console.WriteLine(nestedParameter.UserFriendlyName);
-            }
-
-            Assert.AreEqual(2, flatNestedParameters.Count());
-        }
-
-        [Test]
-        public void Verify_that_the_function_works_with_both_Parameters_and_ParametersOverride_return()
-        {
-            var option = this.iteration.Option.Single(x => x.ShortName == "OPT_B");
-            var flatNestedParameters = this.nestedElementTreeGenerator.GetNestedParameters(option, this.domainOfExpertise);
-
-            Assert.AreEqual(3, flatNestedParameters.Count());
-        }
     }
 }

--- a/CDP4Common.Tests/Helpers/NestedElementTreeGeneratorTestFixtre.cs
+++ b/CDP4Common.Tests/Helpers/NestedElementTreeGeneratorTestFixtre.cs
@@ -28,6 +28,7 @@ namespace CDP4Common.Tests.Helpers
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Linq;
 
     using CDP4Common.CommonData;
@@ -70,57 +71,141 @@ namespace CDP4Common.Tests.Helpers
                 ShortName = "OPT_A",
                 Name = "Option A"
             };
-            this.iteration.Option.Add(option_A);
-            this.iteration.DefaultOption = option_A;
+            
 
             var option_B = new Option(Guid.NewGuid(), this.cache, this.uri)
             {
                 ShortName = "OPT_B",
                 Name = "Option B"
             };
-            this.iteration.Option.Add(option_B);
+            
 
-            var satellite = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri)
+            var elementDefinition_1 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri)
             {
                 ShortName = "Sat",
                 Name = "Satellite"
             };
-            this.iteration.Element.Add(satellite);
-            this.iteration.TopElement = satellite;
+            
 
-            var battery = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri)
+            var elementDefinition_2 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri)
             {
                 ShortName = "Bat",
                 Name = "Battery"
             };
-            this.iteration.Element.Add(battery);
 
-            var battery_a = new ElementUsage(Guid.NewGuid(), this.cache, this.uri)
+            var elementUsage_1 = new ElementUsage(Guid.NewGuid(), this.cache, this.uri)
             {
-                ElementDefinition = battery,
+                ElementDefinition = elementDefinition_2,
                 ShortName = "bat_a",
                 Name = "battery a"
             };
-            satellite.ContainedElement.Add(battery_a);
             
-            var battery_b = new ElementUsage(Guid.NewGuid(), this.cache, this.uri)
+            
+            var elementUsage_2 = new ElementUsage(Guid.NewGuid(), this.cache, this.uri)
             {
-                ElementDefinition = battery,
+                ElementDefinition = elementDefinition_2,
                 ShortName = "bat_b",
                 Name = "battery b"                
             };
-            battery_b.ExcludeOption.Add(option_A);
 
-            satellite.ContainedElement.Add(battery_b);
+            var simpleQuantityKind = new SimpleQuantityKind(Guid.NewGuid(), null, null);
+            simpleQuantityKind.ShortName = "m";
+
+            var parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Owner = this.domainOfExpertise,
+                ParameterType = simpleQuantityKind
+            };
+
+            var parameterOverride = new ParameterOverride(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Owner = this.domainOfExpertise,
+                Parameter = parameter
+            };
+
+            var parameterValueset_1 = new ParameterValueSet()
+            {
+                ActualOption = option_B,
+                Iid = Guid.NewGuid()
+            };
+
+            var parameterValueset_2 = new ParameterValueSet()
+            {
+                ActualOption = option_A,
+                Iid = Guid.NewGuid()
+            };
+
+            var values_1 = new List<string>()
+            {
+                "2"
+            };
+
+            var values_2 = new List<string>()
+            {
+                "3"
+            };
+
+
+            var overrideValueset = new ParameterOverrideValueSet()
+            {
+                ParameterValueSet = parameterValueset_1,
+                Iid = Guid.NewGuid()
+            };
+
+            this.iteration.Option.Add(option_A);
+            this.iteration.Option.Add(option_B);
+            this.iteration.DefaultOption = option_A;
+
+            parameterValueset_1.Manual = new CDP4Common.Types.ValueArray<string>(values_1);
+            parameterValueset_1.Reference = new CDP4Common.Types.ValueArray<string>(values_1);
+            parameterValueset_1.Computed = new CDP4Common.Types.ValueArray<string>(values_1);
+            parameterValueset_1.Formula = new CDP4Common.Types.ValueArray<string>(values_1);
+            parameterValueset_1.ValueSwitch = ParameterSwitchKind.MANUAL;
+
+            parameterValueset_2.Manual = new CDP4Common.Types.ValueArray<string>(values_2);
+            parameterValueset_2.Reference = new CDP4Common.Types.ValueArray<string>(values_2);
+            parameterValueset_2.Computed = new CDP4Common.Types.ValueArray<string>(values_2);
+            parameterValueset_2.Formula = new CDP4Common.Types.ValueArray<string>(values_2);
+            parameterValueset_2.ValueSwitch = ParameterSwitchKind.MANUAL;
+
+            overrideValueset.Manual = new CDP4Common.Types.ValueArray<string>(values_1);
+            overrideValueset.Reference = new CDP4Common.Types.ValueArray<string>(values_1);
+            overrideValueset.Computed = new CDP4Common.Types.ValueArray<string>(values_1);
+            overrideValueset.Formula = new CDP4Common.Types.ValueArray<string>(values_1);
+            overrideValueset.ValueSwitch = ParameterSwitchKind.MANUAL;
+
+            parameter.ValueSet.Add(parameterValueset_1);
+            parameter.ValueSet.Add(parameterValueset_2);
+            parameterOverride.ValueSet.Add(overrideValueset);
+
+            elementUsage_1.ExcludeOption.Add(option_A);
+            elementUsage_1.ParameterOverride.Add(parameterOverride);
+
+            elementDefinition_1.Parameter.Add(parameter);
+            elementDefinition_1.ContainedElement.Add(elementUsage_1);
+            elementDefinition_1.ContainedElement.Add(elementUsage_2);
+            elementDefinition_2.Parameter.Add(parameter);
+
+            this.iteration.Element.Add(elementDefinition_1);
+            this.iteration.Element.Add(elementDefinition_2);
+            this.iteration.TopElement = elementDefinition_1;
+   
         }
 
         [Test]
         public void Verify_that_null_arguments_throws_exception()
         {
+            var option = this.iteration.Option.First();
+
             Assert.Throws<ArgumentNullException>(() => this.nestedElementTreeGenerator.Generate(null, null));
 
-            var option = this.iteration.Option.First();
             Assert.Throws<ArgumentNullException>(() => this.nestedElementTreeGenerator.Generate(option, null));
+
+            Assert.Throws<ArgumentNullException>(() => this.nestedElementTreeGenerator.GetNestedParameters(option, null));
+
+            Assert.Throws<ArgumentNullException>(() => this.nestedElementTreeGenerator.GetNestedParameters(null, null));
+
+            Assert.Throws<ArgumentNullException>(() => this.nestedElementTreeGenerator.GetNestedParameters(null, this.domainOfExpertise));
         }
 
         [Test]
@@ -167,6 +252,41 @@ namespace CDP4Common.Tests.Helpers
             }
 
             Assert.AreEqual(3, nestedElements.Count());
+        }
+
+        [Test]
+        public void Verify_that_the_function_returns_values()
+        {
+            var option = this.iteration.Option.Single(x => x.ShortName == "OPT_A");
+
+            var flatNestedParameters = this.nestedElementTreeGenerator.GetNestedParameters(option, this.domainOfExpertise);
+
+            Assert.IsNotEmpty(flatNestedParameters);
+        }
+
+        [Test]
+        public void Verify_that_the_function_does_not_include_parameters_from_excluded_ElementUsages()
+        {
+            var option = this.iteration.Option.Single(x => x.ShortName == "OPT_A");
+
+            var flatNestedParameters = this.nestedElementTreeGenerator.GetNestedParameters(option, this.domainOfExpertise);
+
+            foreach (var nestedParameter in flatNestedParameters)
+            {
+                Console.WriteLine(nestedParameter.UserFriendlyName);
+            }
+
+            Assert.AreEqual(2, flatNestedParameters.Count());
+        }
+
+        [Test]
+        public void Verify_that_the_function_works_with_both_Parameters_and_ParametersOverride_return()
+        {
+            var option = this.iteration.Option.Single(x => x.ShortName == "OPT_B");
+
+            var flatNestedParameters = this.nestedElementTreeGenerator.GetNestedParameters(option, this.domainOfExpertise);
+
+            Assert.AreEqual(3, flatNestedParameters.Count());
         }
     }
 }

--- a/CDP4Common.Tests/Helpers/NestedElementTreeGeneratorTestFixtre.cs
+++ b/CDP4Common.Tests/Helpers/NestedElementTreeGeneratorTestFixtre.cs
@@ -72,21 +72,18 @@ namespace CDP4Common.Tests.Helpers
                 Name = "Option A"
             };
             
-
             var option_B = new Option(Guid.NewGuid(), this.cache, this.uri)
             {
                 ShortName = "OPT_B",
                 Name = "Option B"
             };
             
-
             var elementDefinition_1 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri)
             {
                 ShortName = "Sat",
                 Name = "Satellite"
             };
             
-
             var elementDefinition_2 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri)
             {
                 ShortName = "Bat",
@@ -100,7 +97,6 @@ namespace CDP4Common.Tests.Helpers
                 Name = "battery a"
             };
             
-            
             var elementUsage_2 = new ElementUsage(Guid.NewGuid(), this.cache, this.uri)
             {
                 ElementDefinition = elementDefinition_2,
@@ -108,9 +104,11 @@ namespace CDP4Common.Tests.Helpers
                 Name = "battery b"                
             };
 
-            var simpleQuantityKind = new SimpleQuantityKind(Guid.NewGuid(), null, null);
-            simpleQuantityKind.ShortName = "m";
-
+            var simpleQuantityKind = new SimpleQuantityKind(Guid.NewGuid(), null, null)
+            {
+                ShortName = "m"
+            };
+            
             var parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
             {
                 Owner = this.domainOfExpertise,
@@ -135,16 +133,8 @@ namespace CDP4Common.Tests.Helpers
                 Iid = Guid.NewGuid()
             };
 
-            var values_1 = new List<string>()
-            {
-                "2"
-            };
-
-            var values_2 = new List<string>()
-            {
-                "3"
-            };
-
+            var values_1 = new List<string>() {"2"};
+            var values_2 = new List<string>() {"3"};
 
             var overrideValueset = new ParameterOverrideValueSet()
             {
@@ -189,7 +179,6 @@ namespace CDP4Common.Tests.Helpers
             this.iteration.Element.Add(elementDefinition_1);
             this.iteration.Element.Add(elementDefinition_2);
             this.iteration.TopElement = elementDefinition_1;
-   
         }
 
         [Test]
@@ -258,7 +247,6 @@ namespace CDP4Common.Tests.Helpers
         public void Verify_that_the_function_returns_values()
         {
             var option = this.iteration.Option.Single(x => x.ShortName == "OPT_A");
-
             var flatNestedParameters = this.nestedElementTreeGenerator.GetNestedParameters(option, this.domainOfExpertise);
 
             Assert.IsNotEmpty(flatNestedParameters);
@@ -268,7 +256,6 @@ namespace CDP4Common.Tests.Helpers
         public void Verify_that_the_function_does_not_include_parameters_from_excluded_ElementUsages()
         {
             var option = this.iteration.Option.Single(x => x.ShortName == "OPT_A");
-
             var flatNestedParameters = this.nestedElementTreeGenerator.GetNestedParameters(option, this.domainOfExpertise);
 
             foreach (var nestedParameter in flatNestedParameters)
@@ -283,7 +270,6 @@ namespace CDP4Common.Tests.Helpers
         public void Verify_that_the_function_works_with_both_Parameters_and_ParametersOverride_return()
         {
             var option = this.iteration.Option.Single(x => x.ShortName == "OPT_B");
-
             var flatNestedParameters = this.nestedElementTreeGenerator.GetNestedParameters(option, this.domainOfExpertise);
 
             Assert.AreEqual(3, flatNestedParameters.Count());

--- a/CDP4Common/Helpers/NestedElementTreeGenerator.cs
+++ b/CDP4Common/Helpers/NestedElementTreeGenerator.cs
@@ -131,18 +131,16 @@ namespace CDP4Common.Helpers
             var flatNestedParameters = new List<NestedParameter>();
             var flatElementUsages = iteration.Element.SelectMany(ed => ed.ContainedElement);
 
-            foreach (var ElementUsage in flatElementUsages)
+            foreach (var elementUsage in flatElementUsages)
             {
-                if (ElementUsage.ExcludeOption.Contains(option))
+                if (elementUsage.ExcludeOption.Contains(option))
                 {
-                    Logger.Debug($"Option {option.Name}:{option.Iid} is excluded from the Element Usage {ElementUsage.Name}:{ElementUsage.Iid}");
+                    Logger.Debug($"Option {option.Name}:{option.Iid} is excluded from the Element Usage {elementUsage.Name}:{elementUsage.Iid}");
                     continue;
                 }
 
-                flatNestedParameters.AddRange(this.CreateNestedParameters(ElementUsage, domainOfExpertise, option));
+                flatNestedParameters.AddRange(this.CreateNestedParameters(elementUsage, domainOfExpertise, option));
             }
-
-            //iteration.Element.SelectMany(ed => ed.ContainedElement).SelectMany(eu => this.CreateNestedParameters(eu, domainOfExpertise, option));
 
             return flatNestedParameters.ToList();
         }

--- a/CDP4Common/Helpers/NestedElementTreeGenerator.cs
+++ b/CDP4Common/Helpers/NestedElementTreeGenerator.cs
@@ -95,6 +95,45 @@ namespace CDP4Common.Helpers
         }
 
         /// <summary>
+        /// Returns the <see cref="NestedParameter"/>s in a flat list
+        /// </summary>
+        /// <param name="option">
+        /// The <see cref="Option"/> for which the <see cref="NestedElement"/> tree is created. When the <see cref="Option"/>
+        /// is null then none of the <see cref="ElementUsage"/>s are filtered.
+        /// </param>
+        /// <param name="domainOfExpertise">
+        /// The <see cref="DomainOfExpertise"/> for which the <see cref="NestedElement"/> tree needs to be generated. Only the <see cref="Parameter"/>s, <see cref="ParameterOverride"/>s and
+        /// <see cref="ParameterSubscription"/>s that are owned by the <see cref="DomainOfExpertise"/> will be taken into account when generating <see cref="NestedParameter"/>s
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{NestedElement}"/> that contains the generated <see cref="NestedElement"/>s
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// thrown when the <paramref name="domainOfExpertise"/> is null
+        /// thrown when the <paramref name="option"/> is null
+        /// </exception>
+        public IEnumerable<NestedParameter> GetNestedParameters(Option option, DomainOfExpertise domainOfExpertise)
+        {
+            if (option == null)
+            {
+                throw new ArgumentNullException("option", "The option may not be null");
+            }
+
+            if (domainOfExpertise == null)
+            {
+                throw new ArgumentNullException("domainOfExpertise", "The domainOfExpertise may not be null");
+            }
+
+            var iteration = (Iteration)option.Container;
+
+            Logger.Debug($"Generating NestedParameter for Iteration {iteration.Iid}, Option: {option.ShortName}, DomainOfExpertise {domainOfExpertise.ShortName}");
+
+            var flatNestedParameters = iteration.Element.SelectMany(ed => ed.ContainedElement).SelectMany(eu => CreateNestedParameters(eu, domainOfExpertise, option));
+
+            return flatNestedParameters.ToList();
+        }
+
+        /// <summary>
         /// Generates the <see cref="NestedElement"/>s starting at the <paramref name="rootElement"/>
         /// </summary>
         /// <param name="option">

--- a/CDP4Common/Helpers/NestedElementTreeGenerator.cs
+++ b/CDP4Common/Helpers/NestedElementTreeGenerator.cs
@@ -98,15 +98,15 @@ namespace CDP4Common.Helpers
         /// Returns the <see cref="NestedParameter"/>s in a flat list
         /// </summary>
         /// <param name="option">
-        /// The <see cref="Option"/> for which the <see cref="NestedElement"/> tree is created. When the <see cref="Option"/>
+        /// The <see cref="Option"/> for which the <see cref="NestedParameters"/> flat list is created. When the <see cref="Option"/>
         /// is null then none of the <see cref="ElementUsage"/>s are filtered.
         /// </param>
         /// <param name="domainOfExpertise">
-        /// The <see cref="DomainOfExpertise"/> for which the <see cref="NestedElement"/> tree needs to be generated. Only the <see cref="Parameter"/>s, <see cref="ParameterOverride"/>s and
-        /// <see cref="ParameterSubscription"/>s that are owned by the <see cref="DomainOfExpertise"/> will be taken into account when generating <see cref="NestedParameter"/>s
+        /// The <see cref="DomainOfExpertise"/> for which the <see cref="NestedParameters"/> flat list needs to be generated. Only the <see cref="Parameter"/>s, <see cref="ParameterOverride"/>s and
+        /// <see cref="ParameterSubscription"/>s that are owned by the <see cref="DomainOfExpertise"/> will be taken into account.
         /// </param>
         /// <returns>
-        /// An <see cref="IEnumerable{NestedElement}"/> that contains the generated <see cref="NestedElement"/>s
+        /// An <see cref="IEnumerable{NestedParameter}"/> that contains the generated <see cref="NestedParameters"/>s
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// thrown when the <paramref name="domainOfExpertise"/> is null
@@ -126,9 +126,23 @@ namespace CDP4Common.Helpers
 
             var iteration = (Iteration)option.Container;
 
-            Logger.Debug($"Generating NestedParameter for Iteration {iteration.Iid}, Option: {option.ShortName}, DomainOfExpertise {domainOfExpertise.ShortName}");
+            Logger.Debug($"Generating NestedParameters for Iteration {iteration.Iid}, Option: {option.ShortName}, DomainOfExpertise {domainOfExpertise.ShortName}");
 
-            var flatNestedParameters = iteration.Element.SelectMany(ed => ed.ContainedElement).SelectMany(eu => CreateNestedParameters(eu, domainOfExpertise, option));
+            var flatNestedParameters = new List<NestedParameter>();
+            var flatElementUsages = iteration.Element.SelectMany(ed => ed.ContainedElement);
+
+            foreach (var ElementUsage in flatElementUsages)
+            {
+                if (ElementUsage.ExcludeOption.Contains(option))
+                {
+                    Logger.Debug($"Option {option.Name}:{option.Iid} is excluded from the Element Usage {ElementUsage.Name}:{ElementUsage.Iid}");
+                    continue;
+                }
+
+                flatNestedParameters.AddRange(this.CreateNestedParameters(ElementUsage, domainOfExpertise, option));
+            }
+
+            //iteration.Element.SelectMany(ed => ed.ContainedElement).SelectMany(eu => this.CreateNestedParameters(eu, domainOfExpertise, option));
 
             return flatNestedParameters.ToList();
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The class CDP4Common.Helpers.NestedElementsTreeGenerator was fulfilled with a GetNestedParameters function, which returns all the NestedParameters for the Option as a flat List<NestedParameters>.

<!-- Thanks for contributing to CDP4-SDK! -->