### PR TITLE
GH55 - resolve issue with openging an Iteration when the ActivePerson cannot be determined

### DIFF
--- a/CDP4Dal.NetCore.Tests/SessionTestFixture.cs
+++ b/CDP4Dal.NetCore.Tests/SessionTestFixture.cs
@@ -472,7 +472,7 @@ namespace CDP4Dal.Tests
         }
 
         [Test]
-        public void VerifyThatReadIterationWorks()
+        public async Task VerifyThatReadIterationWorks()
         {
             var siteDir = new CDP4Common.SiteDirectoryData.SiteDirectory(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
             var modelSetup = new CDP4Common.SiteDirectoryData.EngineeringModelSetup(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
@@ -516,13 +516,13 @@ namespace CDP4Dal.Tests
             var modelToOpen = new CDP4Common.EngineeringModelData.EngineeringModel(model.Iid, null, null);
             iterationToOpen.Container = modelToOpen;
 
-            this.session.Read(iterationToOpen, activeDomain).Wait();
+            await this.session.Read(iterationToOpen, activeDomain);
             this.mockedDal.Verify(x => x.Read(It.Is<Iteration>(i => i.Iid == iterationToOpen.Iid), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()), Times.Once);
 
             var pair = this.session.OpenIterations.Single();
             Assert.AreEqual(pair.Value.Item1, activeDomain);
 
-            this.session.Read(iterationToOpen, activeDomain).Wait();
+            await this.session.Read(iterationToOpen, activeDomain);
             this.mockedDal.Verify(x => x.Read(It.Is<Iteration>(i => i.Iid == iterationToOpen.Iid), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()), Times.Exactly(2));
 
             pair = this.session.OpenIterations.Single();
@@ -539,13 +539,12 @@ namespace CDP4Dal.Tests
                     return readTaskCompletionSource.Task;
                 });
 
-            this.session.Refresh().Wait();
+            await this.session.Refresh();
             this.mockedDal.Verify(x => x.Read<Thing>(It.IsAny<Thing>(), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()), Times.Exactly(1));
 
             Assert.ThrowsAsync<InvalidOperationException>(async () => await this.session.Read(iterationToOpen, null));
         }
     
-
         [Test]
         public void VeriyThatCDPVersionIsSet()
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
I added a call to .ActivePerson in the `Open` method to establish when opening a `connection` to a server whether a Person can be found with the same Shortname as the credentials username. If this is not the case a warning is logged -> potentially this already deserves an exception to be thrown? 

Then, when an Iteration is opened and the ActivePerson is null, the method returns and does not query the server.

<!-- Thanks for contributing to CDP4-SDK! -->