### PR TITLE
GH55 - refacor Open method and ActivePerson property

### DIFF
--- a/CDP4Dal.NetCore.Tests/SessionTestFixture.cs
+++ b/CDP4Dal.NetCore.Tests/SessionTestFixture.cs
@@ -150,8 +150,11 @@ namespace CDP4Dal.NetCore.Tests
                     endUpdateReceived = true;
                 }
             });
-            
-            var context = string.Format("/SiteDirectory/{0}", Guid.NewGuid());
+
+            var context = $"/SiteDirectory/{Guid.NewGuid()}";
+
+            var johnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
+            this.session.GetType().GetProperty("ActivePerson").SetValue(session, johnDoe, null);
             await this.session.Write(new OperationContainer(context));
 
             Assert.IsTrue(beginUpdateReceived);

--- a/CDP4Dal.NetCore.Tests/SessionTestFixture.cs
+++ b/CDP4Dal.NetCore.Tests/SessionTestFixture.cs
@@ -22,22 +22,19 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace CDP4Dal.Tests
+namespace CDP4Dal.NetCore.Tests
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using CDP4Common.CommonData;
     using CDP4Common.DTO;
-    using CDP4Common.Helpers;
     using CDP4Common.MetaInfo;
     using CDP4Dal.Operations;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
-
     using CDP4Dal.Composition;
     using CDP4Dal.DAL;
     using CDP4Dal.Events;
@@ -58,35 +55,18 @@ namespace CDP4Dal.Tests
     [TestFixture]
     public class SessionTestFixture
     {
-        /// <summary>
-        /// mocked data service
-        /// </summary>
         private Mock<IDal> mockedDal;
 
-        /// <summary>
-        /// a list of <see cref="CDP4Common.DTO.Thing"/> returned from the mocked <see cref="IDal"/>
-        /// </summary>
         private List<Thing> dalOutputs;
 
-        /// <summary>
-        /// The uri of the mocked <see cref="IDal"/>
-        /// </summary>
         private Uri uri;
 
-        /// <summary>
-        /// The <see cref="Session"/> object under test
-        /// </summary>
         private Session session;
 
-        /// <summary>
-        /// The <see cref="Person"/> object under test
-        /// </summary>
         private CDP4Common.DTO.Person person;
 
         private CDP4Common.DTO.SiteDirectory sieSiteDirectoryDto;
 
-        private CancellationTokenSource tokenSource;
-        
         [SetUp]
         public void SetUp()
         {
@@ -121,8 +101,6 @@ namespace CDP4Dal.Tests
             
             this.session = new Session(this.mockedDal.Object, credentials);
             
-            this.tokenSource = new CancellationTokenSource();
-
             var openTaskCompletionSource = new TaskCompletionSource<IEnumerable<Thing>>();
             openTaskCompletionSource.SetResult(this.dalOutputs);
             this.mockedDal.Setup(x => x.Open(It.IsAny<Credentials>(), It.IsAny<CancellationToken>())).Returns(openTaskCompletionSource.Task);
@@ -243,18 +221,13 @@ namespace CDP4Dal.Tests
             var activePerson = this.session.ActivePerson;
             Assert.IsNotNull(activePerson);
             Assert.AreEqual("John", activePerson.ShortName);
-
-            activePerson = null;
-
-            // query again to cover cached activeperson property
-            activePerson = this.session.ActivePerson;
-            Assert.IsNotNull(activePerson);
         }
 
         [Test]
         public async Task VerifyThatOpenSiteRDLUpdatesListInSession()
         {
             var siteDir = new CDP4Common.SiteDirectoryData.SiteDirectory(Guid.NewGuid(), null, null);
+            var JohnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
             var rdlDto = new CDP4Common.DTO.SiteReferenceDataLibrary { Iid = Guid.NewGuid() };
             var siteDirDto = new CDP4Common.DTO.SiteDirectory() { Iid = Guid.NewGuid() };
             var requiredPocoDto = new CDP4Common.DTO.SiteReferenceDataLibrary() { Iid = Guid.NewGuid() };
@@ -265,7 +238,8 @@ namespace CDP4Dal.Tests
             var session2 = new Session(this.mockedDal.Object, credentials);
             var rdlPoco = new CDP4Common.SiteDirectoryData.SiteReferenceDataLibrary { Iid = rdlDto.Iid, Name = rdlDto.Name, ShortName = rdlDto.ShortName, Container = siteDir, RequiredRdl = requiredPocoRdl };
             var thingsToAdd = new List<Thing>() { siteDirDto, requiredPocoDto, rdlDto };
-            
+
+            session2.GetType().GetProperty("ActivePerson").SetValue(session2, JohnDoe, null);
             await session2.Assembler.Synchronize(thingsToAdd);
 
             Assert.IsEmpty(session2.OpenReferenceDataLibraries);
@@ -282,6 +256,8 @@ namespace CDP4Dal.Tests
         public async Task VerifyThatCloseRdlWorks()
         {
             var siteDirectoryPoco = new CDP4Common.SiteDirectoryData.SiteDirectory(this.sieSiteDirectoryDto.Iid, this.session.Assembler.Cache, this.uri);
+            var JohnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
+            siteDirectoryPoco.Person.Add(JohnDoe);
 
             var rdlDto = new CDP4Common.DTO.SiteReferenceDataLibrary { Iid = Guid.NewGuid() };
             var rdlPoco = new CDP4Common.SiteDirectoryData.SiteReferenceDataLibrary { Iid = rdlDto.Iid, Name = rdlDto.Name, ShortName = rdlDto.ShortName, Container = siteDirectoryPoco };
@@ -294,6 +270,7 @@ namespace CDP4Dal.Tests
 
             var thingsToAdd = new List<Thing>() { requiredSiteReferenceDataLibraryDto, rdlDto };
 
+            session.GetType().GetProperty("ActivePerson").SetValue(session, JohnDoe, null);
             await session.Assembler.Synchronize(thingsToAdd);
             await session.Read(rdlPoco);
             Assert.AreEqual(2, session.OpenReferenceDataLibraries.ToList().Count());
@@ -321,11 +298,13 @@ namespace CDP4Dal.Tests
         public async Task VerifyThatSiteRdlRequiredByModelRdlCannotBeClosed()
         {
             var rdlDto = new CDP4Common.DTO.SiteReferenceDataLibrary { Iid = Guid.NewGuid() };
-            var siteDirDto = new CDP4Common.DTO.SiteDirectory() { Iid = Guid.NewGuid() };
+            var siteDirDto = new CDP4Common.DTO.SiteDirectory { Iid = Guid.NewGuid() };
             var requiredRdlDto = new CDP4Common.DTO.SiteReferenceDataLibrary() { Iid = Guid.NewGuid() };
             rdlDto.RequiredRdl = requiredRdlDto.Iid;
             siteDirDto.SiteReferenceDataLibrary.Add(rdlDto.Iid);
             siteDirDto.SiteReferenceDataLibrary.Add(requiredRdlDto.Iid);
+            
+            siteDirDto.Person.Add(this.person.Iid);
 
             var mrdl = new CDP4Common.DTO.ModelReferenceDataLibrary(Guid.NewGuid(), 0) { RequiredRdl = requiredRdlDto.Iid };
             var modelsetup = new EngineeringModelSetup(Guid.NewGuid(), 0);
@@ -343,7 +322,8 @@ namespace CDP4Dal.Tests
                 mrdl,
                 modelsetup,
                 model,
-                iteration
+                iteration,
+                this.person
             };
 
             var mrdlpoco = new ModelReferenceDataLibrary(mrdl.Iid, null, null);
@@ -363,8 +343,11 @@ namespace CDP4Dal.Tests
                 .Returns(readTaskCompletionSource.Task);
 
             var thingsToAdd = new List<Thing>() { siteDirDto, requiredRdlDto, rdlDto, this.person, participant, modelsetup };
-
             await this.session.Assembler.Synchronize(thingsToAdd);
+
+            var JohnDoe = this.session.RetrieveSiteDirectory().Person.Single(x => x.Iid == this.person.Iid);
+            this.session.GetType().GetProperty("ActivePerson").SetValue(this.session, JohnDoe, null);
+
             await this.session.Read(iterationPoco, null);
             
             Assert.AreEqual(2, this.session.OpenReferenceDataLibraries.Count());
@@ -380,6 +363,7 @@ namespace CDP4Dal.Tests
         public async Task VerifyThatCloseModelRdlWorks()
         {
             var siteDir = new CDP4Common.SiteDirectoryData.SiteDirectory(Guid.NewGuid(), null, null);
+            var JohnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
             var modelRdlDto = new CDP4Common.DTO.ModelReferenceDataLibrary() { Iid = Guid.NewGuid() };
             var siteDirDto = new CDP4Common.DTO.SiteDirectory() { Iid = Guid.NewGuid() };
             var requiredPocoDto = new CDP4Common.DTO.SiteReferenceDataLibrary() { Iid = Guid.NewGuid() };
@@ -388,9 +372,12 @@ namespace CDP4Dal.Tests
             var containerEngModelSetup = new CDP4Common.SiteDirectoryData.EngineeringModelSetup() { Iid = containerEngModelSetupDto.Iid };
             siteDir.Model.Add(containerEngModelSetup);
             modelRdlDto.RequiredRdl = requiredPocoDto.Iid;
-
+            siteDir.Person.Add(JohnDoe);
+            
             var credentials = new Credentials("admin", "pass", new Uri("http://www.rheagroup.com"));
             var session2 = new Session(this.mockedDal.Object, credentials);
+            session2.GetType().GetProperty("ActivePerson").SetValue(session2, JohnDoe, null);
+
             var modelRdlPoco = new ModelReferenceDataLibrary { Iid = modelRdlDto.Iid, Name = modelRdlDto.Name, ShortName = modelRdlDto.ShortName, Container = containerEngModelSetup, RequiredRdl = requiredPocoRdl };
             var thingsToAdd = new List<Thing>() { siteDirDto, requiredPocoDto, containerEngModelSetupDto, modelRdlDto };
 
@@ -445,6 +432,7 @@ namespace CDP4Dal.Tests
         public async Task VerifyThatReadRdlWorks()
         {
             var siteDir = new CDP4Common.SiteDirectoryData.SiteDirectory(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
+            var JohnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
             this.session.Assembler.Cache.TryAdd(new CacheKey(siteDir.Iid, null),
                 new Lazy<CDP4Common.CommonData.Thing>(() => siteDir));
 
@@ -465,6 +453,7 @@ namespace CDP4Dal.Tests
             var srdl = new SiteReferenceDataLibrary(rdl.Iid, null, null);
             srdl.Container = siteDir;
 
+            this.session.GetType().GetProperty("ActivePerson").SetValue(this.session, JohnDoe, null);
             await this.session.Read(srdl);
 
             Assert.AreEqual(1, this.session.OpenReferenceDataLibraries.Count());
@@ -475,6 +464,7 @@ namespace CDP4Dal.Tests
         public async Task VerifyThatReadIterationWorks()
         {
             var siteDir = new CDP4Common.SiteDirectoryData.SiteDirectory(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
+            var JohnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) {ShortName = "John"};
             var modelSetup = new CDP4Common.SiteDirectoryData.EngineeringModelSetup(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
             var iterationSetup = new CDP4Common.SiteDirectoryData.IterationSetup(Guid.NewGuid(), this.session.Assembler.Cache, this.uri) { FrozenOn = DateTime.Now, IterationIid = Guid.NewGuid() };
             var mrdl = new ModelReferenceDataLibrary(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
@@ -486,13 +476,17 @@ namespace CDP4Dal.Tests
             siteDir.Model.Add(modelSetup);
             siteDir.SiteReferenceDataLibrary.Add(srdl);
             siteDir.Domain.Add(activeDomain);
+            siteDir.Person.Add(JohnDoe);
 
             this.session.Assembler.Cache.TryAdd(new CacheKey(siteDir.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => siteDir));
+            this.session.Assembler.Cache.TryAdd(new CacheKey(JohnDoe.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => JohnDoe));
             this.session.Assembler.Cache.TryAdd(new CacheKey(modelSetup.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => modelSetup));
             this.session.Assembler.Cache.TryAdd(new CacheKey(mrdl.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => mrdl));
             this.session.Assembler.Cache.TryAdd(new CacheKey(srdl.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => srdl));
             this.session.Assembler.Cache.TryAdd(new CacheKey(siteDir.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => siteDir));
             this.session.Assembler.Cache.TryAdd(new CacheKey(iterationSetup.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => iterationSetup));
+
+            this.session.GetType().GetProperty("ActivePerson").SetValue(this.session, JohnDoe, null);
 
             var participant = new CDP4Common.SiteDirectoryData.Participant(Guid.NewGuid(), this.session.Assembler.Cache, this.uri) { Person = this.session.ActivePerson };
             modelSetup.Participant.Add(participant);
@@ -515,7 +509,7 @@ namespace CDP4Dal.Tests
             var iterationToOpen = new CDP4Common.EngineeringModelData.Iteration(iteration.Iid, null, null);
             var modelToOpen = new CDP4Common.EngineeringModelData.EngineeringModel(model.Iid, null, null);
             iterationToOpen.Container = modelToOpen;
-
+            
             await this.session.Read(iterationToOpen, activeDomain);
             this.mockedDal.Verify(x => x.Read(It.Is<Iteration>(i => i.Iid == iterationToOpen.Iid), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()), Times.Once);
 
@@ -544,7 +538,22 @@ namespace CDP4Dal.Tests
 
             Assert.ThrowsAsync<InvalidOperationException>(async () => await this.session.Read(iterationToOpen, null));
         }
-    
+
+        [Test]
+        public void Verify_that_when_active_person_is_null_Iteration_is_not_read()
+        {
+            var iterationSetup = new CDP4Common.SiteDirectoryData.IterationSetup(Guid.NewGuid(), null, null) { FrozenOn = DateTime.Now, IterationIid = Guid.NewGuid() };
+            var activeDomain = new DomainOfExpertise(Guid.NewGuid(), null, null);
+            var model = new EngineeringModel(Guid.NewGuid(), 1);
+            var iteration = new Iteration(Guid.NewGuid(), 10) { IterationSetup = iterationSetup.Iid };
+            
+            var iterationToOpen = new CDP4Common.EngineeringModelData.Iteration(iteration.Iid, null, null);
+            var modelToOpen = new CDP4Common.EngineeringModelData.EngineeringModel(model.Iid, null, null);
+            iterationToOpen.Container = modelToOpen;
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await this.session.Read(iterationToOpen, activeDomain));
+        }
+
         [Test]
         public void VeriyThatCDPVersionIsSet()
         {

--- a/CDP4Dal.NetCore.Tests/SessionTestFixture.cs
+++ b/CDP4Dal.NetCore.Tests/SessionTestFixture.cs
@@ -472,7 +472,7 @@ namespace CDP4Dal.Tests
         }
 
         [Test]
-        public void VerifyThatReadIterationWorks()
+        public async Task VerifyThatReadIterationWorks()
         {
             var siteDir = new CDP4Common.SiteDirectoryData.SiteDirectory(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
             var modelSetup = new CDP4Common.SiteDirectoryData.EngineeringModelSetup(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
@@ -516,13 +516,13 @@ namespace CDP4Dal.Tests
             var modelToOpen = new CDP4Common.EngineeringModelData.EngineeringModel(model.Iid, null, null);
             iterationToOpen.Container = modelToOpen;
 
-            this.session.Read(iterationToOpen, activeDomain).Wait();
+            await this.session.Read(iterationToOpen, activeDomain);
             this.mockedDal.Verify(x => x.Read(It.Is<Iteration>(i => i.Iid == iterationToOpen.Iid), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()), Times.Once);
 
             var pair = this.session.OpenIterations.Single();
             Assert.AreEqual(pair.Value.Item1, activeDomain);
 
-            this.session.Read(iterationToOpen, activeDomain).Wait();
+            await this.session.Read(iterationToOpen, activeDomain);
             this.mockedDal.Verify(x => x.Read(It.Is<Iteration>(i => i.Iid == iterationToOpen.Iid), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()), Times.Exactly(2));
 
             pair = this.session.OpenIterations.Single();
@@ -539,13 +539,12 @@ namespace CDP4Dal.Tests
                     return readTaskCompletionSource.Task;
                 });
 
-            this.session.Refresh().Wait();
+            await this.session.Refresh();
             this.mockedDal.Verify(x => x.Read<Thing>(It.IsAny<Thing>(), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()), Times.Exactly(1));
 
             Assert.ThrowsAsync<InvalidOperationException>(async () => await this.session.Read(iterationToOpen, null));
         }
     
-
         [Test]
         public void VeriyThatCDPVersionIsSet()
         {

--- a/CDP4Dal.Tests/SessionTestFixture.cs
+++ b/CDP4Dal.Tests/SessionTestFixture.cs
@@ -25,19 +25,16 @@
 namespace CDP4Dal.Tests
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using CDP4Common.CommonData;
     using CDP4Common.DTO;
-    using CDP4Common.Helpers;
     using CDP4Common.MetaInfo;
     using CDP4Dal.Operations;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
-
     using CDP4Dal.Composition;
     using CDP4Dal.DAL;
     using CDP4Dal.Events;
@@ -58,36 +55,17 @@ namespace CDP4Dal.Tests
     [TestFixture]
     public class SessionTestFixture
     {
-        /// <summary>
-        /// mocked data service
-        /// </summary>
         private Mock<IDal> mockedDal;
 
-        /// <summary>
-        /// a list of <see cref="CDP4Common.DTO.Thing"/> returned from the mocked <see cref="IDal"/>
-        /// </summary>
         private List<Thing> dalOutputs;
 
-        /// <summary>
-        /// The uri of the mocked <see cref="IDal"/>
-        /// </summary>
         private Uri uri;
 
-        /// <summary>
-        /// The <see cref="Session"/> object under test
-        /// </summary>
         private Session session;
 
-        /// <summary>
-        /// The <see cref="Person"/> object under test
-        /// </summary>
         private CDP4Common.DTO.Person person;
 
         private CDP4Common.DTO.SiteDirectory sieSiteDirectoryDto;
-
-        private CancellationTokenSource tokenSource;
-
-        
 
         [SetUp]
         public void SetUp()
@@ -123,8 +101,6 @@ namespace CDP4Dal.Tests
             
             this.session = new Session(this.mockedDal.Object, credentials);
             
-            this.tokenSource = new CancellationTokenSource();
-
             var openTaskCompletionSource = new TaskCompletionSource<IEnumerable<Thing>>();
             openTaskCompletionSource.SetResult(this.dalOutputs);
             this.mockedDal.Setup(x => x.Open(It.IsAny<Credentials>(), It.IsAny<CancellationToken>())).Returns(openTaskCompletionSource.Task);
@@ -245,18 +221,13 @@ namespace CDP4Dal.Tests
             var activePerson = this.session.ActivePerson;
             Assert.IsNotNull(activePerson);
             Assert.AreEqual("John", activePerson.ShortName);
-
-            activePerson = null;
-
-            // query again to cover cached activeperson property
-            activePerson = this.session.ActivePerson;
-            Assert.IsNotNull(activePerson);
         }
 
         [Test]
         public async Task VerifyThatOpenSiteRDLUpdatesListInSession()
         {
             var siteDir = new CDP4Common.SiteDirectoryData.SiteDirectory(Guid.NewGuid(), null, null);
+            var JohnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
             var rdlDto = new CDP4Common.DTO.SiteReferenceDataLibrary { Iid = Guid.NewGuid() };
             var siteDirDto = new CDP4Common.DTO.SiteDirectory() { Iid = Guid.NewGuid() };
             var requiredPocoDto = new CDP4Common.DTO.SiteReferenceDataLibrary() { Iid = Guid.NewGuid() };
@@ -267,7 +238,8 @@ namespace CDP4Dal.Tests
             var session2 = new Session(this.mockedDal.Object, credentials);
             var rdlPoco = new CDP4Common.SiteDirectoryData.SiteReferenceDataLibrary { Iid = rdlDto.Iid, Name = rdlDto.Name, ShortName = rdlDto.ShortName, Container = siteDir, RequiredRdl = requiredPocoRdl };
             var thingsToAdd = new List<Thing>() { siteDirDto, requiredPocoDto, rdlDto };
-            
+
+            session2.GetType().GetProperty("ActivePerson").SetValue(session2, JohnDoe, null);
             await session2.Assembler.Synchronize(thingsToAdd);
 
             Assert.IsEmpty(session2.OpenReferenceDataLibraries);
@@ -276,7 +248,7 @@ namespace CDP4Dal.Tests
 
             Assert.AreEqual(2, session2.OpenReferenceDataLibraries.ToList().Count());
 
-            session2.Close();
+            await session2.Close();
             Assert.IsEmpty(session2.OpenReferenceDataLibraries);
         }
 
@@ -284,6 +256,8 @@ namespace CDP4Dal.Tests
         public async Task VerifyThatCloseRdlWorks()
         {
             var siteDirectoryPoco = new CDP4Common.SiteDirectoryData.SiteDirectory(this.sieSiteDirectoryDto.Iid, this.session.Assembler.Cache, this.uri);
+            var JohnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
+            siteDirectoryPoco.Person.Add(JohnDoe);
 
             var rdlDto = new CDP4Common.DTO.SiteReferenceDataLibrary { Iid = Guid.NewGuid() };
             var rdlPoco = new CDP4Common.SiteDirectoryData.SiteReferenceDataLibrary { Iid = rdlDto.Iid, Name = rdlDto.Name, ShortName = rdlDto.ShortName, Container = siteDirectoryPoco };
@@ -296,6 +270,7 @@ namespace CDP4Dal.Tests
 
             var thingsToAdd = new List<Thing>() { requiredSiteReferenceDataLibraryDto, rdlDto };
 
+            session.GetType().GetProperty("ActivePerson").SetValue(session, JohnDoe, null);
             await session.Assembler.Synchronize(thingsToAdd);
             await session.Read(rdlPoco);
             Assert.AreEqual(2, session.OpenReferenceDataLibraries.ToList().Count());
@@ -329,6 +304,8 @@ namespace CDP4Dal.Tests
             siteDirDto.SiteReferenceDataLibrary.Add(rdlDto.Iid);
             siteDirDto.SiteReferenceDataLibrary.Add(requiredRdlDto.Iid);
 
+            siteDirDto.Person.Add(this.person.Iid);
+
             var mrdl = new CDP4Common.DTO.ModelReferenceDataLibrary(Guid.NewGuid(), 0) { RequiredRdl = requiredRdlDto.Iid };
             var modelsetup = new EngineeringModelSetup(Guid.NewGuid(), 0);
             modelsetup.RequiredRdl.Add(mrdl.Iid);
@@ -345,7 +322,8 @@ namespace CDP4Dal.Tests
                 mrdl,
                 modelsetup,
                 model,
-                iteration
+                iteration,
+                this.person
             };
 
             var mrdlpoco = new ModelReferenceDataLibrary(mrdl.Iid, null, null);
@@ -365,8 +343,11 @@ namespace CDP4Dal.Tests
                 .Returns(readTaskCompletionSource.Task);
 
             var thingsToAdd = new List<Thing>() { siteDirDto, requiredRdlDto, rdlDto, this.person, participant, modelsetup };
-
             await this.session.Assembler.Synchronize(thingsToAdd);
+
+            var JohnDoe = this.session.RetrieveSiteDirectory().Person.Single(x => x.Iid == this.person.Iid);
+            this.session.GetType().GetProperty("ActivePerson").SetValue(this.session, JohnDoe, null);
+
             await this.session.Read(iterationPoco, null);
             
             Assert.AreEqual(2, this.session.OpenReferenceDataLibraries.Count());
@@ -382,6 +363,7 @@ namespace CDP4Dal.Tests
         public async Task VerifyThatCloseModelRdlWorks()
         {
             var siteDir = new CDP4Common.SiteDirectoryData.SiteDirectory(Guid.NewGuid(), null, null);
+            var JohnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
             var modelRdlDto = new CDP4Common.DTO.ModelReferenceDataLibrary() { Iid = Guid.NewGuid() };
             var siteDirDto = new CDP4Common.DTO.SiteDirectory() { Iid = Guid.NewGuid() };
             var requiredPocoDto = new CDP4Common.DTO.SiteReferenceDataLibrary() { Iid = Guid.NewGuid() };
@@ -390,9 +372,12 @@ namespace CDP4Dal.Tests
             var containerEngModelSetup = new CDP4Common.SiteDirectoryData.EngineeringModelSetup() { Iid = containerEngModelSetupDto.Iid };
             siteDir.Model.Add(containerEngModelSetup);
             modelRdlDto.RequiredRdl = requiredPocoDto.Iid;
+            siteDir.Person.Add(JohnDoe);
 
             var credentials = new Credentials("admin", "pass", new Uri("http://www.rheagroup.com"));
             var session2 = new Session(this.mockedDal.Object, credentials);
+            session2.GetType().GetProperty("ActivePerson").SetValue(session2, JohnDoe, null);
+            
             var modelRdlPoco = new ModelReferenceDataLibrary { Iid = modelRdlDto.Iid, Name = modelRdlDto.Name, ShortName = modelRdlDto.ShortName, Container = containerEngModelSetup, RequiredRdl = requiredPocoRdl };
             var thingsToAdd = new List<Thing>() { siteDirDto, requiredPocoDto, containerEngModelSetupDto, modelRdlDto };
 
@@ -447,6 +432,7 @@ namespace CDP4Dal.Tests
         public async Task VerifyThatReadRdlWorks()
         {
             var siteDir = new CDP4Common.SiteDirectoryData.SiteDirectory(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
+            var JohnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
             this.session.Assembler.Cache.TryAdd(new CacheKey(siteDir.Iid, null),
                 new Lazy<CDP4Common.CommonData.Thing>(() => siteDir));
 
@@ -467,6 +453,7 @@ namespace CDP4Dal.Tests
             var srdl = new SiteReferenceDataLibrary(rdl.Iid, null, null);
             srdl.Container = siteDir;
 
+            this.session.GetType().GetProperty("ActivePerson").SetValue(this.session, JohnDoe, null);
             await this.session.Read(srdl);
 
             Assert.AreEqual(1, this.session.OpenReferenceDataLibraries.Count());
@@ -474,11 +461,12 @@ namespace CDP4Dal.Tests
         }
 
         [Test]
-        public void VerifyThatReadIterationWorks()
+        public async Task VerifyThatReadIterationWorks()
         {
             var siteDir = new CDP4Common.SiteDirectoryData.SiteDirectory(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
+            var JohnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
             var modelSetup = new CDP4Common.SiteDirectoryData.EngineeringModelSetup(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
-            var iterationSetup = new CDP4Common.SiteDirectoryData.IterationSetup(Guid.NewGuid(), this.session.Assembler.Cache, this.uri) { FrozenOn = DateTime.Now, IterationIid = Guid.NewGuid()};
+            var iterationSetup = new CDP4Common.SiteDirectoryData.IterationSetup(Guid.NewGuid(), this.session.Assembler.Cache, this.uri) { FrozenOn = DateTime.Now, IterationIid = Guid.NewGuid() };
             var mrdl = new ModelReferenceDataLibrary(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
             var srdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
             var activeDomain = new DomainOfExpertise(Guid.NewGuid(), this.session.Assembler.Cache, this.uri);
@@ -488,19 +476,23 @@ namespace CDP4Dal.Tests
             siteDir.Model.Add(modelSetup);
             siteDir.SiteReferenceDataLibrary.Add(srdl);
             siteDir.Domain.Add(activeDomain);
+            siteDir.Person.Add(JohnDoe);
 
             this.session.Assembler.Cache.TryAdd(new CacheKey(siteDir.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => siteDir));
+            this.session.Assembler.Cache.TryAdd(new CacheKey(JohnDoe.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => JohnDoe));
             this.session.Assembler.Cache.TryAdd(new CacheKey(modelSetup.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => modelSetup));
             this.session.Assembler.Cache.TryAdd(new CacheKey(mrdl.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => mrdl));
             this.session.Assembler.Cache.TryAdd(new CacheKey(srdl.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => srdl));
             this.session.Assembler.Cache.TryAdd(new CacheKey(siteDir.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => siteDir));
             this.session.Assembler.Cache.TryAdd(new CacheKey(iterationSetup.Iid, null), new Lazy<CDP4Common.CommonData.Thing>(() => iterationSetup));
 
-            var participant = new CDP4Common.SiteDirectoryData.Participant(Guid.NewGuid(),this.session.Assembler.Cache, this.uri) { Person = this.session.ActivePerson };
+            this.session.GetType().GetProperty("ActivePerson").SetValue(this.session, JohnDoe, null);
+
+            var participant = new CDP4Common.SiteDirectoryData.Participant(Guid.NewGuid(), this.session.Assembler.Cache, this.uri) { Person = this.session.ActivePerson };
             modelSetup.Participant.Add(participant);
 
             var model = new EngineeringModel(Guid.NewGuid(), 1);
-            var iteration = new Iteration(iterationSetup.IterationIid, 1) { IterationSetup = iterationSetup.Iid };
+            var iteration = new Iteration(iterationSetup.IterationIid, 10) { IterationSetup = iterationSetup.Iid };
             model.Iteration.Add(iteration.Iid);
             model.EngineeringModelSetup = modelSetup.Iid;
 
@@ -518,22 +510,48 @@ namespace CDP4Dal.Tests
             var modelToOpen = new CDP4Common.EngineeringModelData.EngineeringModel(model.Iid, null, null);
             iterationToOpen.Container = modelToOpen;
 
-            this.session.Read(iterationToOpen, activeDomain).Wait();
+            await this.session.Read(iterationToOpen, activeDomain);
+            this.mockedDal.Verify(x => x.Read(It.Is<Iteration>(i => i.Iid == iterationToOpen.Iid), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()), Times.Once);
 
             var pair = this.session.OpenIterations.Single();
             Assert.AreEqual(pair.Value.Item1, activeDomain);
-            
-            this.session.Read(iterationToOpen, activeDomain).Wait();
+
+            await this.session.Read(iterationToOpen, activeDomain);
+            this.mockedDal.Verify(x => x.Read(It.Is<Iteration>(i => i.Iid == iterationToOpen.Iid), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()), Times.Exactly(2));
+
             pair = this.session.OpenIterations.Single();
             Assert.AreEqual(pair.Value.Item1, activeDomain);
 
             var selectedDomain = this.session.QuerySelectedDomainOfExpertise(iterationToOpen);
             Assert.AreEqual(activeDomain.Iid, selectedDomain.Iid);
 
-            this.session.Refresh().Wait();
+            this.mockedDal.Setup(x => x.Read(It.IsAny<Thing>(), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>())).Returns<Thing, CancellationToken, IQueryAttributes>(
+                (x, y, z) =>
+                {
+                    // the method with iteration is called
+                    var xvariable = x;
+                    return readTaskCompletionSource.Task;
+                });
+
+            await this.session.Refresh();
             this.mockedDal.Verify(x => x.Read<Thing>(It.IsAny<Thing>(), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()), Times.Exactly(1));
 
             Assert.ThrowsAsync<InvalidOperationException>(async () => await this.session.Read(iterationToOpen, null));
+        }
+
+        [Test]
+        public async Task Verify_that_when_active_person_is_null_Iteration_is_not_read()
+        {
+            var iterationSetup = new CDP4Common.SiteDirectoryData.IterationSetup(Guid.NewGuid(), null, null) { FrozenOn = DateTime.Now, IterationIid = Guid.NewGuid() };
+            var activeDomain = new DomainOfExpertise(Guid.NewGuid(), null, null);
+            var model = new EngineeringModel(Guid.NewGuid(), 1);
+            var iteration = new Iteration(Guid.NewGuid(), 10) { IterationSetup = iterationSetup.Iid };
+
+            var iterationToOpen = new CDP4Common.EngineeringModelData.Iteration(iteration.Iid, null, null);
+            var modelToOpen = new CDP4Common.EngineeringModelData.EngineeringModel(model.Iid, null, null);
+            iterationToOpen.Container = modelToOpen;
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await this.session.Read(iterationToOpen, activeDomain));
         }
 
         [Test]

--- a/CDP4Dal.Tests/SessionTestFixture.cs
+++ b/CDP4Dal.Tests/SessionTestFixture.cs
@@ -151,7 +151,10 @@ namespace CDP4Dal.Tests
                 }
             });
             
-            var context = string.Format("/SiteDirectory/{0}", Guid.NewGuid());
+            var context = $"/SiteDirectory/{Guid.NewGuid()}";
+
+            var johnDoe = new CDP4Common.SiteDirectoryData.Person(this.person.Iid, this.session.Assembler.Cache, this.uri) { ShortName = "John" };
+            this.session.GetType().GetProperty("ActivePerson").SetValue(session, johnDoe, null);
             await this.session.Write(new OperationContainer(context));
 
             Assert.IsTrue(beginUpdateReceived);

--- a/CDP4Dal/Session.cs
+++ b/CDP4Dal/Session.cs
@@ -312,6 +312,9 @@ namespace CDP4Dal
 
             if (this.ActivePerson == null)
             {
+                // clear cache
+                await this.Assembler.Clear();
+
                 throw new IncompleteModelException("The Person object that matches the user specified in the Credentials could not be found");
             }
 
@@ -357,7 +360,7 @@ namespace CDP4Dal
         {
             if (this.ActivePerson == null)
             {
-                throw new InvalidOperationException("The Iteration cannot be read when the ActivePerson is null; The Open method must be used prior to any of the Read methods");
+                throw new InvalidOperationException("The Iteration cannot be read when the ActivePerson is null; The Open method must be called prior to any of the Read methods");
             }
 
             // check if iteration is already open
@@ -417,7 +420,7 @@ namespace CDP4Dal
         {
             if (this.ActivePerson == null)
             {
-                throw new InvalidOperationException("The Iteration cannot be read when the ActivePerson is null; The Open method must be used prior to any of the Read methods");
+                throw new InvalidOperationException("The ReferenceDataLibrary cannot be read when the ActivePerson is null; The Open method must be called prior to any of the Read methods");
             }
 
             await this.Read((Thing)rdl);
@@ -435,7 +438,7 @@ namespace CDP4Dal
         {
             if (this.ActivePerson == null)
             {
-                throw new InvalidOperationException("The Iteration cannot be read when the ActivePerson is null; The Open method must be used prior to any of the Read methods");
+                throw new InvalidOperationException($"The {thing.ClassKind} cannot be read when the ActivePerson is null; The Open method must be called prior to any of the Read methods");
             }
 
             logger.Info("Session.Read {0} {1}", thing.ClassKind, thing.Iid);
@@ -481,6 +484,11 @@ namespace CDP4Dal
         /// </returns>
         public async Task Write(OperationContainer operationContainer)
         {
+            if (this.ActivePerson == null)
+            {
+                throw new InvalidOperationException($"The Write operation cannot be performed when the ActivePerson is null; The Open method must be called prior to performing a Write.");
+            }
+
             this.Dal.Session = this;
             var dtoThings = await this.Dal.Write(operationContainer);
 
@@ -506,6 +514,11 @@ namespace CDP4Dal
         /// </returns>
         public async Task Refresh()
         {
+            if (this.ActivePerson == null)
+            {
+                throw new InvalidOperationException($"The Refresh operation cannot be performed when the ActivePerson is null; The Open method must be called prior to performing a Write.");
+            }
+
             foreach (var topContainer in this.GetSiteDirectoryAndActiveIterations())
             {
                 await this.Update(topContainer);
@@ -520,6 +533,11 @@ namespace CDP4Dal
         /// </returns>
         public async Task Reload()
         {
+            if (this.ActivePerson == null)
+            {
+                throw new InvalidOperationException($"The Reload operation cannot be performed when the ActivePerson is null; The Open method must be called prior to performing a Write.");
+            }
+
             foreach (var topContainer in this.GetSiteDirectoryAndActiveIterations())
             {
                 await this.Update(topContainer, false);

--- a/CDP4Dal/Session.cs
+++ b/CDP4Dal/Session.cs
@@ -30,13 +30,12 @@ namespace CDP4Dal
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.Exceptions;
     using CDP4Common.Types;
     using CDP4Dal.Operations;
     using CDP4Common.SiteDirectoryData;
-
     using DAL;
     using Events;
     using NLog;
@@ -52,16 +51,11 @@ namespace CDP4Dal
         /// The NLog logger
         /// </summary>
         private static Logger logger = LogManager.GetCurrentClassLogger();
-
+        
         /// <summary>
-        /// Backing field for <see cref="ActivePerson"/>
+        /// The cancellation token source.
         /// </summary>
-        private Person activePerson;
-
-        /// <summary>
-        /// The cancelation token source.
-        /// </summary>
-        private CancellationTokenSource cancelationTokenSource;
+        private CancellationTokenSource cancellationTokenSource;
 
         /// <summary>
         /// Backing field for <see cref="OpenReferenceDataLibraries"/>
@@ -137,23 +131,7 @@ namespace CDP4Dal
         /// <summary>
         /// Gets the active <see cref="Person"/> in this <see cref="Session"/>
         /// </summary>
-        public Person ActivePerson
-        {
-            get
-            {
-                if (this.activePerson != null)
-                {
-                    return this.activePerson;
-                }
-
-                this.activePerson = this.Assembler.Cache.Select(x => x.Value)
-                    .Select(lazy => lazy.Value)
-                    .OfType<Person>()
-                    .SingleOrDefault(pers => pers.ShortName == this.Credentials.UserName);
-
-                return this.activePerson;
-            }
-        }
+        public Person ActivePerson { get; private set; }
 
         /// <summary>
         /// Retrieves the <see cref="Participant"/>s from the <see cref="Iteration"/>s that are currently open
@@ -306,16 +284,16 @@ namespace CDP4Dal
             logger.Info("Open request {0}", this.DataSourceUri);
 
             // Create the token source
-            this.cancelationTokenSource = new CancellationTokenSource();
+            this.cancellationTokenSource = new CancellationTokenSource();
             IReadOnlyList<CDP4Common.DTO.Thing> dtoThings;
             try
             {
-                dtoThings = (await this.Dal.Open(this.Credentials, this.cancelationTokenSource.Token)).ToList();
+                dtoThings = (await this.Dal.Open(this.Credentials, this.cancellationTokenSource.Token)).ToList();
             }
             catch (OperationCanceledException)
             {
                 logger.Info("Open request cancelled {0}", this.DataSourceUri);
-                this.cancelationTokenSource = null;
+                this.cancellationTokenSource = null;
                 return;
             }
 
@@ -326,6 +304,17 @@ namespace CDP4Dal
 
             CDPMessageBus.Current.SendMessage(new SessionEvent(this, SessionStatus.BeginUpdate));
             await this.Assembler.Synchronize(dtoThings);
+
+            this.ActivePerson = this.Assembler.Cache.Select(x => x.Value)
+                .Select(lazy => lazy.Value)
+                .OfType<Person>()
+                .SingleOrDefault(pers => pers.ShortName == this.Credentials.UserName);
+
+            if (this.ActivePerson == null)
+            {
+                throw new IncompleteModelException("The Person object that matches the user specified in the Credentials could not be found");
+            }
+
             CDPMessageBus.Current.SendMessage(new SessionEvent(this, SessionStatus.EndUpdate));
 
             logger.Info("Synchronization with the {0} server done in {1} [ms]", this.DataSourceUri, sw.ElapsedMilliseconds);
@@ -366,6 +355,11 @@ namespace CDP4Dal
         /// </remarks>
         public async Task Read(Iteration iteration, DomainOfExpertise domain)
         {
+            if (this.ActivePerson == null)
+            {
+                throw new InvalidOperationException("The Iteration cannot be read when the ActivePerson is null; The Open method must be used prior to any of the Read methods");
+            }
+
             // check if iteration is already open
             // if so check that the domain is not different
             var iterationDomainPair = this.openIterations.SingleOrDefault(x => x.Key.Iid == iteration.Iid);
@@ -378,18 +372,18 @@ namespace CDP4Dal
             }
 
             // Create the token source
-            this.cancelationTokenSource = new CancellationTokenSource();
+            this.cancellationTokenSource = new CancellationTokenSource();
             IEnumerable<CDP4Common.DTO.Thing> dtoThings;
             try
             {
                 var iterationDto = (CDP4Common.DTO.Iteration)iteration.ToDto();
                 this.Dal.Session = this;
-                dtoThings = await this.Dal.Read(iterationDto, this.cancelationTokenSource.Token);
+                dtoThings = await this.Dal.Read(iterationDto, this.cancellationTokenSource.Token);
             }
             catch (OperationCanceledException)
             {
                 logger.Info("Session.Read {0} {1} cancelled", iteration.ClassKind, iteration.Iid);
-                this.cancelationTokenSource = null;
+                this.cancellationTokenSource = null;
                 return;
             }
 
@@ -421,6 +415,11 @@ namespace CDP4Dal
         /// </remarks>
         public async Task Read(ReferenceDataLibrary rdl)
         {
+            if (this.ActivePerson == null)
+            {
+                throw new InvalidOperationException("The Iteration cannot be read when the ActivePerson is null; The Open method must be used prior to any of the Read methods");
+            }
+
             await this.Read((Thing)rdl);
             this.AddRdlToOpenList(rdl);
         }
@@ -434,20 +433,25 @@ namespace CDP4Dal
         /// </returns>
         public async Task Read(Thing thing)
         {
+            if (this.ActivePerson == null)
+            {
+                throw new InvalidOperationException("The Iteration cannot be read when the ActivePerson is null; The Open method must be used prior to any of the Read methods");
+            }
+
             logger.Info("Session.Read {0} {1}", thing.ClassKind, thing.Iid);
             var dto = thing.ToDto();
 
             // Create the token source
-            this.cancelationTokenSource = new CancellationTokenSource();
+            this.cancellationTokenSource = new CancellationTokenSource();
             IEnumerable<CDP4Common.DTO.Thing> dtoThings;
             try
             {
-                dtoThings = await this.Dal.Read(dto, this.cancelationTokenSource.Token);
+                dtoThings = await this.Dal.Read(dto, this.cancellationTokenSource.Token);
             }
             catch (OperationCanceledException)
             {
                 logger.Info("Session.Read {0} {1} cancelled", thing.ClassKind, thing.Iid);
-                this.cancelationTokenSource = null;
+                this.cancellationTokenSource = null;
                 return;
             }
 
@@ -497,7 +501,7 @@ namespace CDP4Dal
         /// <summary>
         /// Refreshes all the <see cref="TopContainer"/>s in the cache
         /// </summary>
-        /// /// <returns>
+        /// <returns>
         /// an await-able <see cref="Task"/>
         /// </returns>
         public async Task Refresh()
@@ -527,9 +531,9 @@ namespace CDP4Dal
         /// </summary>
         public void Cancel()
         {
-            if (this.cancelationTokenSource != null)
+            if (this.cancellationTokenSource != null)
             {
-                this.cancelationTokenSource.Cancel();
+                this.cancellationTokenSource.Cancel();
             }
         }
 
@@ -546,6 +550,8 @@ namespace CDP4Dal
 
             logger.Info("Session {0} closed successfully", this.DataSourceUri);
             this.openReferenceDataLibraries.Clear();
+
+            this.ActivePerson = null;
         }
 
         /// <summary>
@@ -613,15 +619,15 @@ namespace CDP4Dal
             var queryAttribute = new DalQueryAttributes { RevisionNumber = revisionNumber };
 
             // Create the token source
-            this.cancelationTokenSource = new CancellationTokenSource();
+            this.cancellationTokenSource = new CancellationTokenSource();
             IEnumerable<CDP4Common.DTO.Thing> dtoThings;
             try
             {
-                dtoThings = await this.Dal.Read(thing.ToDto(), this.cancelationTokenSource.Token, queryAttribute);
+                dtoThings = await this.Dal.Read(thing.ToDto(), this.cancellationTokenSource.Token, queryAttribute);
             }
             catch (OperationCanceledException)
             {
-                this.cancelationTokenSource = null;
+                this.cancellationTokenSource = null;
                 return;
             }
 
@@ -743,6 +749,7 @@ namespace CDP4Dal
             var iteration = lazyIteraion.Value as Iteration;
             if (iteration == null)
             {
+                logger.Warn("The iteration {iterationId} is not present in the Cache and is therefore not added to the OpenIterations", iterationId);
                 return;
             }
 
@@ -751,11 +758,11 @@ namespace CDP4Dal
                 return;
             }
 
-            var activeParticipant = ((EngineeringModel)iteration.Container).EngineeringModelSetup.Participant.Where(p => p.Person == this.ActivePerson).SingleOrDefault();
+            var activeParticipant = ((EngineeringModel)iteration.Container).EngineeringModelSetup.Participant.SingleOrDefault(p => p.Person == this.ActivePerson);
 
             if (activeParticipant == null)
             {
-                throw new InvalidOperationException("The iteration does not have an active participant associated.");
+                throw new InvalidOperationException("The iteration does not have an active associated participant.");
             }
 
             this.openIterations.Add(iteration, new Tuple<DomainOfExpertise, Participant>(activeDomain, activeParticipant));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The Session.Open method has been refactored to set the `ActivePerson` property. If the person is not found in the JSON response an exception is thrown. Calling methods on session are not allowed when the `ActivePerson` has not been set. 

<!-- Thanks for contributing to CDP4-SDK! -->