### PR TITLE
OrderedItemList is not properly cloned. Assembler preserves the state…

### DIFF
--- a/CDP4Common.NetCore.Tests/Poco/PossibleFiniteStateListTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Poco/PossibleFiniteStateListTestFixture.cs
@@ -1,0 +1,41 @@
+﻿using CDP4Common.EngineeringModelData;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CDP4Common.NetCore.Tests.Poco
+{
+    class PossibleFiniteStateListTestFixture
+    {
+        [Test]
+        public void OrderedItemListIsNotClonedCorrectlyTest()
+        {
+            var pfs1 = new PossibleFiniteState(Guid.NewGuid(), null, null);
+            pfs1.Name = "state1";
+            pfs1.ShortName = "s1";
+
+            var pfs2 = new PossibleFiniteState(Guid.NewGuid(), null, null);
+            pfs2.Name = "state1";
+            pfs2.ShortName = "s1";
+
+            var pfsList = new PossibleFiniteStateList(Guid.NewGuid(), null, null);
+            pfsList.Name = "PossibleFiniteStateList1";
+            pfsList.ShortName = "PFSL1";
+
+            pfsList.PossibleState.Add(pfs1);
+            pfsList.PossibleState.Add(pfs2);
+
+            var dtoOrderedItemListOriginal = pfsList.PossibleState.ToDtoOrderedItemList().ToList();
+
+            var pfsListClone = pfsList.Clone(true);
+            var dtoOrderedItemListClone = pfsListClone.PossibleState.ToDtoOrderedItemList().ToList();
+
+            Assert.AreNotEqual(dtoOrderedItemListOriginal[0].K, dtoOrderedItemListClone[0].K);
+            Assert.AreEqual(dtoOrderedItemListOriginal[0].V, dtoOrderedItemListClone[0].V);
+            Assert.AreNotEqual(dtoOrderedItemListOriginal[1].K, dtoOrderedItemListClone[1].K);
+            Assert.AreEqual(dtoOrderedItemListOriginal[1].V, dtoOrderedItemListClone[1].V);
+        }
+    }
+}


### PR DESCRIPTION
… of OrderedItemList.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
It looks like Assembler preserves keys of OrderedItemLists properly, but once an OrderedItemList is cloned then a clone gets absolutely new keys that are not synchronized with the original object. Two tests are added to prove this. An example of where  OrderedItemList is cloned [here](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/blob/development/CDP4Common/AutoGenPoco/PossibleFiniteStateList.cs#L171). It is clear that it adds new items and for each new item a new key is generted. That is why keys are not synchronized.

