### PR TITLE
[Update] PostOperation tests by adding a check for serialization

### DIFF
--- a/CDP4ServicesDal.NetCore.Tests/PostOperationTestFixture.cs
+++ b/CDP4ServicesDal.NetCore.Tests/PostOperationTestFixture.cs
@@ -1,9 +1,8 @@
-﻿#region Copyright
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PostOperationTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -22,7 +21,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4ServicesDal.Tests
 {
@@ -37,6 +35,10 @@ namespace CDP4ServicesDal.Tests
     using CDP4ServicesDal.Tests.Helper;
     using Newtonsoft.Json;
     using NUnit.Framework;
+    using CDP4Common.Types;
+    using File = System.IO.File;
+    using CDP4Common.DTO;
+    using CDP4Common.CommonData;
 
     [TestFixture]
     public class PostOperationTestFixture
@@ -58,6 +60,73 @@ namespace CDP4ServicesDal.Tests
             {
                 var test = this.serializer.Deserialize<TestPostOperation>(stream);
                 Assert.AreEqual(1, test.Copy.Count);
+            }
+        }
+
+        [Test]
+        public void Verify_that_serialization_of_Post_Operation_returns_expected_result()
+        {
+            var expected = @"{""_delete"":[],""_create"":[{""category"":[],""classKind"":""File"",""excludedDomain"":[],""excludedPerson"":[],""fileRevision"":[""cb54801a-9a08-495f-996c-6467a86ed9cc""],""iid"":""643e6154-a035-4445-a4f2-2c7ff5d2fdbd"",""lockedBy"":null,""modifiedOn"":""0001-01-01T00:00:00.000Z"",""owner"":""0e92edde-fdff-41db-9b1d-f2e484f12535"",""revisionNumber"":0},{""classKind"":""FileRevision"",""containingFolder"":null,""contentHash"":""F73747371CFD9473C19A0A7F99BCAB008474C4CA"",""createdOn"":""0001-01-01T00:00:00.000Z"",""creator"":""284334dd-e8e5-42d6-bc8a-715c507a7f02"",""excludedDomain"":[],""excludedPerson"":[],""fileType"":[{""k"":1,""v"":""b16894e4-acb5-4e81-a118-16c00eb86d8f""}],""iid"":""cb54801a-9a08-495f-996c-6467a86ed9cc"",""modifiedOn"":""0001-01-01T00:00:00.000Z"",""name"":""testfile"",""revisionNumber"":0}],""_update"":[{""classKind"":""DomainFileStore"",""iid"":""da7dddaa-02aa-4897-9935-e8d66c811a96"",""file"":[""643e6154-a035-4445-a4f2-2c7ff5d2fdbd""]}],""_copy"":[]}";
+
+            var engineeringModelIid = Guid.Parse("9ec982e4-ef72-4953-aa85-b158a95d8d56");
+            var iterationIid = Guid.Parse("e163c5ad-f32b-4387-b805-f4b34600bc2c");
+            var domainFileStoreIid = Guid.Parse("da7dddaa-02aa-4897-9935-e8d66c811a96");
+            var fileIid = Guid.Parse("643e6154-a035-4445-a4f2-2c7ff5d2fdbd");
+            var fileRevisionIid = Guid.Parse("cb54801a-9a08-495f-996c-6467a86ed9cc");
+            var domainOfExpertiseIid = Guid.Parse("0e92edde-fdff-41db-9b1d-f2e484f12535");
+            var fileTypeIid = Guid.Parse("b16894e4-acb5-4e81-a118-16c00eb86d8f");
+            var participantIid = Guid.Parse("284334dd-e8e5-42d6-bc8a-715c507a7f02");
+
+            var originalDomainFileStore = new DomainFileStore(domainFileStoreIid, 0);
+            originalDomainFileStore.AddContainer(ClassKind.Iteration, iterationIid);
+            originalDomainFileStore.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var modifiedDomainFileStore = originalDomainFileStore.DeepClone<DomainFileStore>();
+            modifiedDomainFileStore.File.Add(fileIid);
+
+            var file = new CDP4Common.DTO.File(fileIid, 0);
+            file.Owner = domainOfExpertiseIid;
+            file.FileRevision.Add(fileRevisionIid);
+            file.AddContainer(ClassKind.DomainFileStore, domainFileStoreIid);
+            file.AddContainer(ClassKind.Iteration, iterationIid);
+            file.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var fileRevision = new FileRevision(fileRevisionIid, 0);
+            fileRevision.Name = "testfile";
+            fileRevision.ContentHash = "F73747371CFD9473C19A0A7F99BCAB008474C4CA";
+            fileRevision.FileType.Add(new OrderedItem() { K = 1, V = fileTypeIid });
+            fileRevision.Creator = participantIid;
+            fileRevision.AddContainer(ClassKind.File, fileIid);
+            fileRevision.AddContainer(ClassKind.DomainFileStore, domainFileStoreIid);
+            fileRevision.AddContainer(ClassKind.Iteration, iterationIid);
+            fileRevision.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var context = $"/EngineeringModel/{engineeringModelIid}/iteration/{iterationIid}";
+            var operationContainer = new OperationContainer(context, null);
+
+            var updateCommonFileStoreOperation = new Operation(originalDomainFileStore, modifiedDomainFileStore, OperationKind.Update);
+            operationContainer.AddOperation(updateCommonFileStoreOperation);
+
+            var createFileOperation = new Operation(null, file, OperationKind.Create);
+            operationContainer.AddOperation(createFileOperation);
+
+            var createFileRevisionOperation = new Operation(null, fileRevision, OperationKind.Create);
+            operationContainer.AddOperation(createFileRevisionOperation);
+
+            var postOperation = new CdpPostOperation(new MetaDataProvider(), null);
+
+            foreach (var operation in operationContainer.Operations)
+            {
+                postOperation.ConstructFromOperation(operation);
+            }
+
+            using (var stream = new MemoryStream())
+            using (var streamReader = new StreamReader(stream))
+            {
+                this.serializer.SerializeToStream(postOperation, stream);
+
+                stream.Position = 0;
+                Assert.AreEqual(expected, streamReader.ReadToEnd());
             }
         }
 

--- a/CDP4ServicesDal.Tests/PostOperationTestFixture.cs
+++ b/CDP4ServicesDal.Tests/PostOperationTestFixture.cs
@@ -1,9 +1,8 @@
-﻿#region Copyright
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PostOperationTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -22,7 +21,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4ServicesDal.Tests
 {
@@ -39,6 +37,8 @@ namespace CDP4ServicesDal.Tests
     using Newtonsoft.Json;
     using NUnit.Framework;
     using File = System.IO.File;
+    using CDP4Common.CommonData;
+    using CDP4Common.Types;
 
     [TestFixture]
     public class PostOperationTestFixture
@@ -60,6 +60,72 @@ namespace CDP4ServicesDal.Tests
             {
                 var test = this.serializer.Deserialize<TestPostOperation>(stream);
                 Assert.AreEqual(1, test.Copy.Count);
+            }
+        }
+
+        [Test]
+        public void Verify_that_serialization_of_Post_Operation_returns_expected_result()
+        {
+            var expected = @"{""_delete"":[],""_create"":[{""category"":[],""classKind"":""File"",""excludedDomain"":[],""excludedPerson"":[],""fileRevision"":[""cb54801a-9a08-495f-996c-6467a86ed9cc""],""iid"":""643e6154-a035-4445-a4f2-2c7ff5d2fdbd"",""lockedBy"":null,""modifiedOn"":""0001-01-01T00:00:00.000Z"",""owner"":""0e92edde-fdff-41db-9b1d-f2e484f12535"",""revisionNumber"":0},{""classKind"":""FileRevision"",""containingFolder"":null,""contentHash"":""F73747371CFD9473C19A0A7F99BCAB008474C4CA"",""createdOn"":""0001-01-01T00:00:00.000Z"",""creator"":""284334dd-e8e5-42d6-bc8a-715c507a7f02"",""excludedDomain"":[],""excludedPerson"":[],""fileType"":[{""k"":1,""v"":""b16894e4-acb5-4e81-a118-16c00eb86d8f""}],""iid"":""cb54801a-9a08-495f-996c-6467a86ed9cc"",""modifiedOn"":""0001-01-01T00:00:00.000Z"",""name"":""testfile"",""revisionNumber"":0}],""_update"":[{""classKind"":""DomainFileStore"",""iid"":""da7dddaa-02aa-4897-9935-e8d66c811a96"",""file"":[""643e6154-a035-4445-a4f2-2c7ff5d2fdbd""]}],""_copy"":[]}";
+
+            var engineeringModelIid = Guid.Parse("9ec982e4-ef72-4953-aa85-b158a95d8d56");
+            var iterationIid = Guid.Parse("e163c5ad-f32b-4387-b805-f4b34600bc2c");
+            var domainFileStoreIid = Guid.Parse("da7dddaa-02aa-4897-9935-e8d66c811a96");
+            var fileIid = Guid.Parse("643e6154-a035-4445-a4f2-2c7ff5d2fdbd");
+            var fileRevisionIid = Guid.Parse("cb54801a-9a08-495f-996c-6467a86ed9cc");
+            var domainOfExpertiseIid = Guid.Parse("0e92edde-fdff-41db-9b1d-f2e484f12535");
+            var fileTypeIid = Guid.Parse("b16894e4-acb5-4e81-a118-16c00eb86d8f");
+            var participantIid = Guid.Parse("284334dd-e8e5-42d6-bc8a-715c507a7f02");
+
+            var originalDomainFileStore = new DomainFileStore(domainFileStoreIid, 0);
+            originalDomainFileStore.AddContainer(ClassKind.Iteration, iterationIid);
+            originalDomainFileStore.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+             var modifiedDomainFileStore = originalDomainFileStore.DeepClone<DomainFileStore>();
+            modifiedDomainFileStore.File.Add(fileIid);
+
+            var file = new CDP4Common.DTO.File(fileIid, 0);
+            file.Owner = domainOfExpertiseIid;
+            file.FileRevision.Add(fileRevisionIid);
+            file.AddContainer(ClassKind.DomainFileStore, domainFileStoreIid);
+            file.AddContainer(ClassKind.Iteration, iterationIid);
+            file.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var fileRevision = new FileRevision(fileRevisionIid, 0);
+            fileRevision.Name = "testfile";
+            fileRevision.ContentHash = "F73747371CFD9473C19A0A7F99BCAB008474C4CA";
+            fileRevision.FileType.Add(new OrderedItem() {K = 1, V = fileTypeIid });
+            fileRevision.Creator = participantIid;
+            fileRevision.AddContainer(ClassKind.File, fileIid);
+            fileRevision.AddContainer(ClassKind.DomainFileStore, domainFileStoreIid);
+            fileRevision.AddContainer(ClassKind.Iteration, iterationIid);
+            fileRevision.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var context = $"/EngineeringModel/{engineeringModelIid}/iteration/{iterationIid}";
+            var operationContainer = new OperationContainer(context, null);
+
+            var updateCommonFileStoreOperation = new Operation(originalDomainFileStore, modifiedDomainFileStore, OperationKind.Update);
+            operationContainer.AddOperation(updateCommonFileStoreOperation);
+
+            var createFileOperation = new Operation(null, file, OperationKind.Create);
+            operationContainer.AddOperation(createFileOperation);
+
+            var createFileRevisionOperation = new Operation(null, fileRevision, OperationKind.Create);
+            operationContainer.AddOperation(createFileRevisionOperation);
+
+            var postOperation = new CdpPostOperation(new MetaDataProvider(), null);
+
+            foreach (var operation in operationContainer.Operations) {
+                postOperation.ConstructFromOperation(operation);
+            }
+
+            using (var stream = new MemoryStream())
+            using (var streamReader = new StreamReader(stream))
+            {
+                this.serializer.SerializeToStream(postOperation, stream);
+
+                stream.Position = 0;
+                Assert.AreEqual(expected, streamReader.ReadToEnd());
             }
         }
 

--- a/CDP4WspDal.NetCore.Tests/PostOperationTestFixture.cs
+++ b/CDP4WspDal.NetCore.Tests/PostOperationTestFixture.cs
@@ -1,9 +1,8 @@
-﻿#region Copyright
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PostOperationTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -22,7 +21,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4WspDal.Tests
 {
@@ -37,6 +35,10 @@ namespace CDP4WspDal.Tests
     using CDP4WspDal.Tests.Helper;
     using Newtonsoft.Json;
     using NUnit.Framework;
+    using CDP4Common.DTO;
+    using CDP4Common.CommonData;
+    using CDP4Common.Types;
+    using File = System.IO.File;
 
     [TestFixture]
     public class PostOperationTestFixture
@@ -57,6 +59,73 @@ namespace CDP4WspDal.Tests
             using (var stream = StreamHelper.GenerateStreamFromString(response))
             {
                 Assert.DoesNotThrow(() => this.serializer.Deserialize<TestPostOperation>(stream));
+            }
+        }
+
+        [Test]
+        public void Verify_that_serialization_of_Post_Operation_returns_expected_result()
+        {
+            var expected = @"{""_delete"":[],""_create"":[{""category"":[],""classKind"":""File"",""excludedDomain"":[],""excludedPerson"":[],""fileRevision"":[""cb54801a-9a08-495f-996c-6467a86ed9cc""],""iid"":""643e6154-a035-4445-a4f2-2c7ff5d2fdbd"",""lockedBy"":null,""modifiedOn"":""0001-01-01T00:00:00.000Z"",""owner"":""0e92edde-fdff-41db-9b1d-f2e484f12535"",""revisionNumber"":0},{""classKind"":""FileRevision"",""containingFolder"":null,""contentHash"":""F73747371CFD9473C19A0A7F99BCAB008474C4CA"",""createdOn"":""0001-01-01T00:00:00.000Z"",""creator"":""284334dd-e8e5-42d6-bc8a-715c507a7f02"",""excludedDomain"":[],""excludedPerson"":[],""fileType"":[{""k"":1,""v"":""b16894e4-acb5-4e81-a118-16c00eb86d8f""}],""iid"":""cb54801a-9a08-495f-996c-6467a86ed9cc"",""modifiedOn"":""0001-01-01T00:00:00.000Z"",""name"":""testfile"",""revisionNumber"":0}],""_update"":[{""classKind"":""DomainFileStore"",""iid"":""da7dddaa-02aa-4897-9935-e8d66c811a96"",""file"":[""643e6154-a035-4445-a4f2-2c7ff5d2fdbd""]}]}";
+
+            var engineeringModelIid = Guid.Parse("9ec982e4-ef72-4953-aa85-b158a95d8d56");
+            var iterationIid = Guid.Parse("e163c5ad-f32b-4387-b805-f4b34600bc2c");
+            var domainFileStoreIid = Guid.Parse("da7dddaa-02aa-4897-9935-e8d66c811a96");
+            var fileIid = Guid.Parse("643e6154-a035-4445-a4f2-2c7ff5d2fdbd");
+            var fileRevisionIid = Guid.Parse("cb54801a-9a08-495f-996c-6467a86ed9cc");
+            var domainOfExpertiseIid = Guid.Parse("0e92edde-fdff-41db-9b1d-f2e484f12535");
+            var fileTypeIid = Guid.Parse("b16894e4-acb5-4e81-a118-16c00eb86d8f");
+            var participantIid = Guid.Parse("284334dd-e8e5-42d6-bc8a-715c507a7f02");
+
+            var originalDomainFileStore = new DomainFileStore(domainFileStoreIid, 0);
+            originalDomainFileStore.AddContainer(ClassKind.Iteration, iterationIid);
+            originalDomainFileStore.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var modifiedDomainFileStore = originalDomainFileStore.DeepClone<DomainFileStore>();
+            modifiedDomainFileStore.File.Add(fileIid);
+
+            var file = new CDP4Common.DTO.File(fileIid, 0);
+            file.Owner = domainOfExpertiseIid;
+            file.FileRevision.Add(fileRevisionIid);
+            file.AddContainer(ClassKind.DomainFileStore, domainFileStoreIid);
+            file.AddContainer(ClassKind.Iteration, iterationIid);
+            file.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var fileRevision = new FileRevision(fileRevisionIid, 0);
+            fileRevision.Name = "testfile";
+            fileRevision.ContentHash = "F73747371CFD9473C19A0A7F99BCAB008474C4CA";
+            fileRevision.FileType.Add(new OrderedItem() { K = 1, V = fileTypeIid });
+            fileRevision.Creator = participantIid;
+            fileRevision.AddContainer(ClassKind.File, fileIid);
+            fileRevision.AddContainer(ClassKind.DomainFileStore, domainFileStoreIid);
+            fileRevision.AddContainer(ClassKind.Iteration, iterationIid);
+            fileRevision.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var context = $"/EngineeringModel/{engineeringModelIid}/iteration/{iterationIid}";
+            var operationContainer = new OperationContainer(context, null);
+
+            var updateCommonFileStoreOperation = new Operation(originalDomainFileStore, modifiedDomainFileStore, OperationKind.Update);
+            operationContainer.AddOperation(updateCommonFileStoreOperation);
+
+            var createFileOperation = new Operation(null, file, OperationKind.Create);
+            operationContainer.AddOperation(createFileOperation);
+
+            var createFileRevisionOperation = new Operation(null, fileRevision, OperationKind.Create);
+            operationContainer.AddOperation(createFileRevisionOperation);
+
+            var postOperation = new WspPostOperation(new MetaDataProvider());
+
+            foreach (var operation in operationContainer.Operations)
+            {
+                postOperation.ConstructFromOperation(operation);
+            }
+
+            using (var stream = new MemoryStream())
+            using (var streamReader = new StreamReader(stream))
+            {
+                this.serializer.SerializeToStream(postOperation, stream);
+
+                stream.Position = 0;
+                Assert.AreEqual(expected, streamReader.ReadToEnd());
             }
         }
 

--- a/CDP4WspDal.Tests/PostOperationTestFixture.cs
+++ b/CDP4WspDal.Tests/PostOperationTestFixture.cs
@@ -1,9 +1,8 @@
-﻿#region Copyright
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PostOperationTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -22,7 +21,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4WspDal.Tests
 {
@@ -38,7 +36,9 @@ namespace CDP4WspDal.Tests
     using CDP4WspDal.Tests.Helper;
     using Newtonsoft.Json;
     using NUnit.Framework;
+    using CDP4Common.Types;
     using File = System.IO.File;
+    using CDP4Common.CommonData;
 
     [TestFixture]
     public class PostOperationTestFixture
@@ -62,6 +62,72 @@ namespace CDP4WspDal.Tests
             }
         }
 
+        [Test]
+        public void Verify_that_serialization_of_Post_Operation_returns_expected_result()
+        {
+            var expected = @"{""_delete"":[],""_create"":[{""category"":[],""classKind"":""File"",""excludedDomain"":[],""excludedPerson"":[],""fileRevision"":[""cb54801a-9a08-495f-996c-6467a86ed9cc""],""iid"":""643e6154-a035-4445-a4f2-2c7ff5d2fdbd"",""lockedBy"":null,""modifiedOn"":""0001-01-01T00:00:00.000Z"",""owner"":""0e92edde-fdff-41db-9b1d-f2e484f12535"",""revisionNumber"":0},{""classKind"":""FileRevision"",""containingFolder"":null,""contentHash"":""F73747371CFD9473C19A0A7F99BCAB008474C4CA"",""createdOn"":""0001-01-01T00:00:00.000Z"",""creator"":""284334dd-e8e5-42d6-bc8a-715c507a7f02"",""excludedDomain"":[],""excludedPerson"":[],""fileType"":[{""k"":1,""v"":""b16894e4-acb5-4e81-a118-16c00eb86d8f""}],""iid"":""cb54801a-9a08-495f-996c-6467a86ed9cc"",""modifiedOn"":""0001-01-01T00:00:00.000Z"",""name"":""testfile"",""revisionNumber"":0}],""_update"":[{""classKind"":""DomainFileStore"",""iid"":""da7dddaa-02aa-4897-9935-e8d66c811a96"",""file"":[""643e6154-a035-4445-a4f2-2c7ff5d2fdbd""]}]}";
+
+            var engineeringModelIid = Guid.Parse("9ec982e4-ef72-4953-aa85-b158a95d8d56");
+            var iterationIid = Guid.Parse("e163c5ad-f32b-4387-b805-f4b34600bc2c");
+            var domainFileStoreIid = Guid.Parse("da7dddaa-02aa-4897-9935-e8d66c811a96");
+            var fileIid = Guid.Parse("643e6154-a035-4445-a4f2-2c7ff5d2fdbd");
+            var fileRevisionIid = Guid.Parse("cb54801a-9a08-495f-996c-6467a86ed9cc");
+            var domainOfExpertiseIid = Guid.Parse("0e92edde-fdff-41db-9b1d-f2e484f12535");
+            var fileTypeIid = Guid.Parse("b16894e4-acb5-4e81-a118-16c00eb86d8f");
+            var participantIid = Guid.Parse("284334dd-e8e5-42d6-bc8a-715c507a7f02");
+
+            var originalDomainFileStore = new DomainFileStore(domainFileStoreIid, 0);
+            originalDomainFileStore.AddContainer(ClassKind.Iteration, iterationIid);
+            originalDomainFileStore.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var modifiedDomainFileStore = originalDomainFileStore.DeepClone<DomainFileStore>();
+            modifiedDomainFileStore.File.Add(fileIid);
+
+            var file = new CDP4Common.DTO.File(fileIid, 0);
+            file.Owner = domainOfExpertiseIid;
+            file.FileRevision.Add(fileRevisionIid);
+            file.AddContainer(ClassKind.DomainFileStore, domainFileStoreIid);
+            file.AddContainer(ClassKind.Iteration, iterationIid);
+            file.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var fileRevision = new FileRevision(fileRevisionIid, 0);
+            fileRevision.Name = "testfile";
+            fileRevision.ContentHash = "F73747371CFD9473C19A0A7F99BCAB008474C4CA";
+            fileRevision.FileType.Add(new OrderedItem() { K = 1, V = fileTypeIid });
+            fileRevision.Creator = participantIid;
+            fileRevision.AddContainer(ClassKind.File, fileIid);
+            fileRevision.AddContainer(ClassKind.DomainFileStore, domainFileStoreIid);
+            fileRevision.AddContainer(ClassKind.Iteration, iterationIid);
+            fileRevision.AddContainer(ClassKind.EngineeringModel, engineeringModelIid);
+
+            var context = $"/EngineeringModel/{engineeringModelIid}/iteration/{iterationIid}";
+            var operationContainer = new OperationContainer(context, null);
+
+            var updateCommonFileStoreOperation = new Operation(originalDomainFileStore, modifiedDomainFileStore, OperationKind.Update);
+            operationContainer.AddOperation(updateCommonFileStoreOperation);
+
+            var createFileOperation = new Operation(null, file, OperationKind.Create);
+            operationContainer.AddOperation(createFileOperation);
+
+            var createFileRevisionOperation = new Operation(null, fileRevision, OperationKind.Create);
+            operationContainer.AddOperation(createFileRevisionOperation);
+
+            var postOperation = new WspPostOperation(new MetaDataProvider());
+
+            foreach (var operation in operationContainer.Operations)
+            {
+                postOperation.ConstructFromOperation(operation);
+            }
+
+            using (var stream = new MemoryStream())
+            using (var streamReader = new StreamReader(stream))
+            {
+                this.serializer.SerializeToStream(postOperation, stream);
+
+                stream.Position = 0;
+                Assert.AreEqual(expected, streamReader.ReadToEnd());
+            }
+        }
         private class TestPostOperation : PostOperation
         {
             public override void ConstructFromOperation(Operation operation)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
PostOperation tests are extended by adding a check for serialization. Closes #57 