### PR TITLE
GH78 - Implement stable serialization of properties

### DIFF
--- a/CDP4Common.Tests/Comparers/GuidComparerTestFixture.cs
+++ b/CDP4Common.Tests/Comparers/GuidComparerTestFixture.cs
@@ -1,0 +1,53 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GuidComparer.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Tests.Comparers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using CDP4Common.Comparers;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class GuidComparerTestFixture
+    {
+        [Test]
+        public void Verify_that_List_of_Guid_is_ordered()
+        {
+            var id_1 = Guid.Parse("622d8e0f-ed5e-4dde-92b8-97ff06e69110");
+            var id_2 = Guid.Parse("90e43d0c-edf8-4630-963b-90e6530ac9db");
+            var id_3 = Guid.Parse("47b3abc1-ce06-40ef-8ea6-466e7eaccccd");
+
+            Assert.That(-1, Is.EqualTo(id_1.CompareTo(id_2)));
+
+            var ids = new List<Guid> { id_1, id_2, id_3 };
+            var ordered = new List<Guid> { id_3, id_1, id_2 };
+
+            var result = ids.OrderBy(x => x, new GuidComparer());
+
+            CollectionAssert.AreEqual(ordered, result);
+        }
+    }
+}

--- a/CDP4Common/Comparers/GuidComparer.cs
+++ b/CDP4Common/Comparers/GuidComparer.cs
@@ -1,0 +1,48 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GuidComparer.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Comparers
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// an IComparer to compare <see cref="Guid"/>s
+    /// </summary>
+    public class GuidComparer : IComparer<Guid>
+    {
+        /// <summary>
+        /// Compares this instance to a specified object or Guid and returns an indication of their relative values
+        /// </summary>
+        /// <param name="x">the first <see cref="Guid"/> to compare</param>
+        /// <param name="y">the second <see cref="Guid"/> to compare</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and value.
+        /// </returns>
+        public int Compare(Guid x, Guid y)
+        {
+            return x.CompareTo(y);
+        }
+    }
+}

--- a/CDP4Common/Comparers/OrderedItemComparer.cs
+++ b/CDP4Common/Comparers/OrderedItemComparer.cs
@@ -1,0 +1,48 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedItemComparer.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Comparers
+{
+    using System.Collections.Generic;
+    using CDP4Common.Types;
+
+    /// <summary>
+    /// an IComparer to compare <see cref="OrderedItem"/>s
+    /// </summary>
+    public class OrderedItemComparer : IComparer<OrderedItem>
+    {
+        /// <summary>
+        /// Compares two instances of <see cref="OrderedItem"/> based on the value of their respective keys (K).
+        /// </summary>
+        /// <param name="x">the first <see cref="OrderedItem"/> to compare</param>
+        /// <param name="y">the second <see cref="OrderedItem"/> to compare</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and value.
+        /// </returns>
+        public int Compare(OrderedItem x, OrderedItem y)
+        {
+            return x.K.CompareTo(y.K);
+        }
+    }
+}

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ActionItemSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ActionItemSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ActionItemSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ActionItemSerializer"/> class is to provide a <see cref="ActionItem"/> specific serializer
     /// </summary>
-    public class ActionItemSerializer : IThingSerializer
+    public class ActionItemSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -80,28 +79,28 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("actionee", this.PropertySerializerMap["actionee"](actionItem.Actionee));
-            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](actionItem.ApprovedBy));
+            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](actionItem.ApprovedBy.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("author", this.PropertySerializerMap["author"](actionItem.Author));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](actionItem.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](actionItem.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classification", this.PropertySerializerMap["classification"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationClassificationKind), actionItem.Classification)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), actionItem.ClassKind)));
             jsonObject.Add("closeOutDate", this.PropertySerializerMap["closeOutDate"](actionItem.CloseOutDate));
             jsonObject.Add("closeOutStatement", this.PropertySerializerMap["closeOutStatement"](actionItem.CloseOutStatement));
             jsonObject.Add("content", this.PropertySerializerMap["content"](actionItem.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](actionItem.CreatedOn));
-            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](actionItem.Discussion));
+            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](actionItem.Discussion.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("dueDate", this.PropertySerializerMap["dueDate"](actionItem.DueDate));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](actionItem.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](actionItem.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](actionItem.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](actionItem.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](actionItem.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](actionItem.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](actionItem.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](actionItem.Owner));
             jsonObject.Add("primaryAnnotatedThing", this.PropertySerializerMap["primaryAnnotatedThing"](actionItem.PrimaryAnnotatedThing));
-            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](actionItem.RelatedThing));
+            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](actionItem.RelatedThing.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](actionItem.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](actionItem.ShortName));
-            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](actionItem.SourceAnnotation));
+            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](actionItem.SourceAnnotation.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("status", this.PropertySerializerMap["status"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationStatusKind), actionItem.Status)));
             jsonObject.Add("title", this.PropertySerializerMap["title"](actionItem.Title));
             return jsonObject;
@@ -124,7 +123,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var actionItem = thing as ActionItem;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ActualFiniteStateListSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ActualFiniteStateListSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ActualFiniteStateListSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ActualFiniteStateListSerializer"/> class is to provide a <see cref="ActualFiniteStateList"/> specific serializer
     /// </summary>
-    public class ActualFiniteStateListSerializer : IThingSerializer
+    public class ActualFiniteStateListSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,15 +63,15 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ActualFiniteStateList actualFiniteStateList)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("actualState", this.PropertySerializerMap["actualState"](actualFiniteStateList.ActualState));
+            jsonObject.Add("actualState", this.PropertySerializerMap["actualState"](actualFiniteStateList.ActualState.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), actualFiniteStateList.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](actualFiniteStateList.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](actualFiniteStateList.ExcludedPerson));
-            jsonObject.Add("excludeOption", this.PropertySerializerMap["excludeOption"](actualFiniteStateList.ExcludeOption));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](actualFiniteStateList.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](actualFiniteStateList.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludeOption", this.PropertySerializerMap["excludeOption"](actualFiniteStateList.ExcludeOption.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](actualFiniteStateList.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](actualFiniteStateList.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](actualFiniteStateList.Owner));
-            jsonObject.Add("possibleFiniteStateList", this.PropertySerializerMap["possibleFiniteStateList"](actualFiniteStateList.PossibleFiniteStateList));
+            jsonObject.Add("possibleFiniteStateList", this.PropertySerializerMap["possibleFiniteStateList"](actualFiniteStateList.PossibleFiniteStateList.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](actualFiniteStateList.RevisionNumber));
             return jsonObject;
         }
@@ -94,7 +93,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var actualFiniteStateList = thing as ActualFiniteStateList;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ActualFiniteStateSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ActualFiniteStateSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ActualFiniteStateSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ActualFiniteStateSerializer"/> class is to provide a <see cref="ActualFiniteState"/> specific serializer
     /// </summary>
-    public class ActualFiniteStateSerializer : IThingSerializer
+    public class ActualFiniteStateSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,12 +62,12 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), actualFiniteState.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](actualFiniteState.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](actualFiniteState.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](actualFiniteState.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](actualFiniteState.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](actualFiniteState.Iid));
             jsonObject.Add("kind", this.PropertySerializerMap["kind"](Enum.GetName(typeof(CDP4Common.EngineeringModelData.ActualFiniteStateKind), actualFiniteState.Kind)));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](actualFiniteState.ModifiedOn));
-            jsonObject.Add("possibleState", this.PropertySerializerMap["possibleState"](actualFiniteState.PossibleState));
+            jsonObject.Add("possibleState", this.PropertySerializerMap["possibleState"](actualFiniteState.PossibleState.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](actualFiniteState.RevisionNumber));
             return jsonObject;
         }
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var actualFiniteState = thing as ActualFiniteState;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/AliasSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/AliasSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AliasSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="AliasSerializer"/> class is to provide a <see cref="Alias"/> specific serializer
     /// </summary>
-    public class AliasSerializer : IThingSerializer
+    public class AliasSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,8 +64,8 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), alias.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](alias.Content));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](alias.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](alias.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](alias.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](alias.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](alias.Iid));
             jsonObject.Add("isSynonym", this.PropertySerializerMap["isSynonym"](alias.IsSynonym));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](alias.LanguageCode));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var alias = thing as Alias;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/AndExpressionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/AndExpressionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AndExpressionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="AndExpressionSerializer"/> class is to provide a <see cref="AndExpression"/> specific serializer
     /// </summary>
-    public class AndExpressionSerializer : IThingSerializer
+    public class AndExpressionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -62,12 +61,12 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), andExpression.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](andExpression.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](andExpression.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](andExpression.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](andExpression.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](andExpression.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](andExpression.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](andExpression.RevisionNumber));
-            jsonObject.Add("term", this.PropertySerializerMap["term"](andExpression.Term));
+            jsonObject.Add("term", this.PropertySerializerMap["term"](andExpression.Term.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -88,7 +87,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var andExpression = thing as AndExpression;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ApprovalSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ApprovalSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ApprovalSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ApprovalSerializer"/> class is to provide a <see cref="Approval"/> specific serializer
     /// </summary>
-    public class ApprovalSerializer : IThingSerializer
+    public class ApprovalSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,8 +70,8 @@ namespace CDP4JsonSerializer
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), approval.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](approval.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](approval.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](approval.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](approval.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](approval.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](approval.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](approval.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](approval.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](approval.ModifiedOn));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var approval = thing as Approval;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ArrayParameterTypeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ArrayParameterTypeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ArrayParameterTypeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ArrayParameterTypeSerializer"/> class is to provide a <see cref="ArrayParameterType"/> specific serializer
     /// </summary>
-    public class ArrayParameterTypeSerializer : IThingSerializer
+    public class ArrayParameterTypeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -72,15 +71,15 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ArrayParameterType arrayParameterType)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](arrayParameterType.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](arrayParameterType.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](arrayParameterType.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](arrayParameterType.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), arrayParameterType.ClassKind)));
-            jsonObject.Add("component", this.PropertySerializerMap["component"](arrayParameterType.Component));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](arrayParameterType.Definition));
-            jsonObject.Add("dimension", this.PropertySerializerMap["dimension"](arrayParameterType.Dimension));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](arrayParameterType.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](arrayParameterType.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](arrayParameterType.HyperLink));
+            jsonObject.Add("component", this.PropertySerializerMap["component"](arrayParameterType.Component.OrderBy(x => x, this.orderedItemComparer)));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](arrayParameterType.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("dimension", this.PropertySerializerMap["dimension"](arrayParameterType.Dimension.OrderBy(x => x, this.orderedItemComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](arrayParameterType.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](arrayParameterType.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](arrayParameterType.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](arrayParameterType.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](arrayParameterType.IsDeprecated));
             jsonObject.Add("isFinalized", this.PropertySerializerMap["isFinalized"](arrayParameterType.IsFinalized));
@@ -110,7 +109,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var arrayParameterType = thing as ArrayParameterType;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/BinaryNoteSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/BinaryNoteSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BinaryNoteSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="BinaryNoteSerializer"/> class is to provide a <see cref="BinaryNote"/> specific serializer
     /// </summary>
-    public class BinaryNoteSerializer : IThingSerializer
+    public class BinaryNoteSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,11 +67,11 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("caption", this.PropertySerializerMap["caption"](binaryNote.Caption));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](binaryNote.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](binaryNote.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), binaryNote.ClassKind)));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](binaryNote.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](binaryNote.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](binaryNote.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](binaryNote.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](binaryNote.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("fileType", this.PropertySerializerMap["fileType"](binaryNote.FileType));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](binaryNote.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](binaryNote.ModifiedOn));
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var binaryNote = thing as BinaryNote;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/BinaryRelationshipRuleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/BinaryRelationshipRuleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BinaryRelationshipRuleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="BinaryRelationshipRuleSerializer"/> class is to provide a <see cref="BinaryRelationshipRule"/> specific serializer
     /// </summary>
-    public class BinaryRelationshipRuleSerializer : IThingSerializer
+    public class BinaryRelationshipRuleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,13 +70,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(BinaryRelationshipRule binaryRelationshipRule)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](binaryRelationshipRule.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](binaryRelationshipRule.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), binaryRelationshipRule.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](binaryRelationshipRule.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](binaryRelationshipRule.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](binaryRelationshipRule.ExcludedPerson));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](binaryRelationshipRule.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](binaryRelationshipRule.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](binaryRelationshipRule.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("forwardRelationshipName", this.PropertySerializerMap["forwardRelationshipName"](binaryRelationshipRule.ForwardRelationshipName));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](binaryRelationshipRule.HyperLink));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](binaryRelationshipRule.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](binaryRelationshipRule.Iid));
             jsonObject.Add("inverseRelationshipName", this.PropertySerializerMap["inverseRelationshipName"](binaryRelationshipRule.InverseRelationshipName));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](binaryRelationshipRule.IsDeprecated));
@@ -108,7 +107,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var binaryRelationshipRule = thing as BinaryRelationshipRule;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/BinaryRelationshipSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/BinaryRelationshipSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BinaryRelationshipSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="BinaryRelationshipSerializer"/> class is to provide a <see cref="BinaryRelationship"/> specific serializer
     /// </summary>
-    public class BinaryRelationshipSerializer : IThingSerializer
+    public class BinaryRelationshipSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,14 +64,14 @@ namespace CDP4JsonSerializer
         private JObject Serialize(BinaryRelationship binaryRelationship)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("category", this.PropertySerializerMap["category"](binaryRelationship.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](binaryRelationship.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), binaryRelationship.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](binaryRelationship.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](binaryRelationship.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](binaryRelationship.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](binaryRelationship.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](binaryRelationship.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](binaryRelationship.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](binaryRelationship.Owner));
-            jsonObject.Add("parameterValue", this.PropertySerializerMap["parameterValue"](binaryRelationship.ParameterValue));
+            jsonObject.Add("parameterValue", this.PropertySerializerMap["parameterValue"](binaryRelationship.ParameterValue.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](binaryRelationship.RevisionNumber));
             jsonObject.Add("source", this.PropertySerializerMap["source"](binaryRelationship.Source));
             jsonObject.Add("target", this.PropertySerializerMap["target"](binaryRelationship.Target));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var binaryRelationship = thing as BinaryRelationship;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/BookSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/BookSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BookSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="BookSerializer"/> class is to provide a <see cref="Book"/> specific serializer
     /// </summary>
-    public class BookSerializer : IThingSerializer
+    public class BookSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,17 +65,17 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Book book)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("category", this.PropertySerializerMap["category"](book.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](book.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), book.ClassKind)));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](book.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](book.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](book.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](book.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](book.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](book.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](book.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](book.Name));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](book.Owner));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](book.RevisionNumber));
-            jsonObject.Add("section", this.PropertySerializerMap["section"](book.Section));
+            jsonObject.Add("section", this.PropertySerializerMap["section"](book.Section.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](book.ShortName));
             return jsonObject;
         }
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var book = thing as Book;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/BooleanParameterTypeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/BooleanParameterTypeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BooleanParameterTypeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="BooleanParameterTypeSerializer"/> class is to provide a <see cref="BooleanParameterType"/> specific serializer
     /// </summary>
-    public class BooleanParameterTypeSerializer : IThingSerializer
+    public class BooleanParameterTypeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,13 +67,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(BooleanParameterType booleanParameterType)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](booleanParameterType.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](booleanParameterType.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](booleanParameterType.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](booleanParameterType.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), booleanParameterType.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](booleanParameterType.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](booleanParameterType.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](booleanParameterType.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](booleanParameterType.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](booleanParameterType.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](booleanParameterType.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](booleanParameterType.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](booleanParameterType.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](booleanParameterType.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](booleanParameterType.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](booleanParameterType.ModifiedOn));
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var booleanParameterType = thing as BooleanParameterType;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/BoundsSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/BoundsSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BoundsSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="BoundsSerializer"/> class is to provide a <see cref="Bounds"/> specific serializer
     /// </summary>
-    public class BoundsSerializer : IThingSerializer
+    public class BoundsSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,8 +65,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), bounds.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](bounds.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](bounds.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](bounds.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](bounds.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("height", this.PropertySerializerMap["height"](bounds.Height));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](bounds.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](bounds.ModifiedOn));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var bounds = thing as Bounds;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/BuiltInRuleVerificationSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/BuiltInRuleVerificationSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BuiltInRuleVerificationSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="BuiltInRuleVerificationSerializer"/> class is to provide a <see cref="BuiltInRuleVerification"/> specific serializer
     /// </summary>
-    public class BuiltInRuleVerificationSerializer : IThingSerializer
+    public class BuiltInRuleVerificationSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,8 +64,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), builtInRuleVerification.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](builtInRuleVerification.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](builtInRuleVerification.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](builtInRuleVerification.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](builtInRuleVerification.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("executedOn", this.PropertySerializerMap["executedOn"](builtInRuleVerification.ExecutedOn));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](builtInRuleVerification.Iid));
             jsonObject.Add("isActive", this.PropertySerializerMap["isActive"](builtInRuleVerification.IsActive));
@@ -94,7 +93,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var builtInRuleVerification = thing as BuiltInRuleVerification;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/CategorySerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/CategorySerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CategorySerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="CategorySerializer"/> class is to provide a <see cref="Category"/> specific serializer
     /// </summary>
-    public class CategorySerializer : IThingSerializer
+    public class CategorySerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -69,12 +68,12 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Category category)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](category.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](category.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), category.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](category.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](category.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](category.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](category.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](category.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](category.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](category.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](category.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](category.Iid));
             jsonObject.Add("isAbstract", this.PropertySerializerMap["isAbstract"](category.IsAbstract));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](category.IsDeprecated));
@@ -83,7 +82,7 @@ namespace CDP4JsonSerializer
             jsonObject.Add("permissibleClass", this.PropertySerializerMap["permissibleClass"](category.PermissibleClass.Select(e => Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), e))));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](category.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](category.ShortName));
-            jsonObject.Add("superCategory", this.PropertySerializerMap["superCategory"](category.SuperCategory));
+            jsonObject.Add("superCategory", this.PropertySerializerMap["superCategory"](category.SuperCategory.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -104,7 +103,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var category = thing as Category;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ChangeProposalSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ChangeProposalSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ChangeProposalSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ChangeProposalSerializer"/> class is to provide a <see cref="ChangeProposal"/> specific serializer
     /// </summary>
-    public class ChangeProposalSerializer : IThingSerializer
+    public class ChangeProposalSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -76,26 +75,26 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ChangeProposal changeProposal)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](changeProposal.ApprovedBy));
+            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](changeProposal.ApprovedBy.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("author", this.PropertySerializerMap["author"](changeProposal.Author));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](changeProposal.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](changeProposal.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("changeRequest", this.PropertySerializerMap["changeRequest"](changeProposal.ChangeRequest));
             jsonObject.Add("classification", this.PropertySerializerMap["classification"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationClassificationKind), changeProposal.Classification)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), changeProposal.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](changeProposal.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](changeProposal.CreatedOn));
-            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](changeProposal.Discussion));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](changeProposal.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](changeProposal.ExcludedPerson));
+            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](changeProposal.Discussion.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](changeProposal.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](changeProposal.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](changeProposal.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](changeProposal.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](changeProposal.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](changeProposal.Owner));
             jsonObject.Add("primaryAnnotatedThing", this.PropertySerializerMap["primaryAnnotatedThing"](changeProposal.PrimaryAnnotatedThing));
-            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](changeProposal.RelatedThing));
+            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](changeProposal.RelatedThing.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](changeProposal.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](changeProposal.ShortName));
-            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](changeProposal.SourceAnnotation));
+            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](changeProposal.SourceAnnotation.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("status", this.PropertySerializerMap["status"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationStatusKind), changeProposal.Status)));
             jsonObject.Add("title", this.PropertySerializerMap["title"](changeProposal.Title));
             return jsonObject;
@@ -118,7 +117,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var changeProposal = thing as ChangeProposal;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ChangeRequestSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ChangeRequestSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ChangeRequestSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ChangeRequestSerializer"/> class is to provide a <see cref="ChangeRequest"/> specific serializer
     /// </summary>
-    public class ChangeRequestSerializer : IThingSerializer
+    public class ChangeRequestSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -75,25 +74,25 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ChangeRequest changeRequest)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](changeRequest.ApprovedBy));
+            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](changeRequest.ApprovedBy.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("author", this.PropertySerializerMap["author"](changeRequest.Author));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](changeRequest.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](changeRequest.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classification", this.PropertySerializerMap["classification"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationClassificationKind), changeRequest.Classification)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), changeRequest.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](changeRequest.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](changeRequest.CreatedOn));
-            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](changeRequest.Discussion));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](changeRequest.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](changeRequest.ExcludedPerson));
+            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](changeRequest.Discussion.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](changeRequest.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](changeRequest.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](changeRequest.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](changeRequest.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](changeRequest.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](changeRequest.Owner));
             jsonObject.Add("primaryAnnotatedThing", this.PropertySerializerMap["primaryAnnotatedThing"](changeRequest.PrimaryAnnotatedThing));
-            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](changeRequest.RelatedThing));
+            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](changeRequest.RelatedThing.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](changeRequest.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](changeRequest.ShortName));
-            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](changeRequest.SourceAnnotation));
+            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](changeRequest.SourceAnnotation.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("status", this.PropertySerializerMap["status"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationStatusKind), changeRequest.Status)));
             jsonObject.Add("title", this.PropertySerializerMap["title"](changeRequest.Title));
             return jsonObject;
@@ -116,7 +115,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var changeRequest = thing as ChangeRequest;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/CitationSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/CitationSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CitationSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="CitationSerializer"/> class is to provide a <see cref="Citation"/> specific serializer
     /// </summary>
-    public class CitationSerializer : IThingSerializer
+    public class CitationSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,8 +65,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), citation.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](citation.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](citation.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](citation.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](citation.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](citation.Iid));
             jsonObject.Add("isAdaptation", this.PropertySerializerMap["isAdaptation"](citation.IsAdaptation));
             jsonObject.Add("location", this.PropertySerializerMap["location"](citation.Location));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var citation = thing as Citation;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ColorSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ColorSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ColorSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ColorSerializer"/> class is to provide a <see cref="Color"/> specific serializer
     /// </summary>
-    public class ColorSerializer : IThingSerializer
+    public class ColorSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,8 +65,8 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("blue", this.PropertySerializerMap["blue"](color.Blue));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), color.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](color.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](color.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](color.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](color.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("green", this.PropertySerializerMap["green"](color.Green));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](color.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](color.ModifiedOn));
@@ -94,7 +93,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var color = thing as Color;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/CommonFileStoreSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/CommonFileStoreSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CommonFileStoreSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="CommonFileStoreSerializer"/> class is to provide a <see cref="CommonFileStore"/> specific serializer
     /// </summary>
-    public class CommonFileStoreSerializer : IThingSerializer
+    public class CommonFileStoreSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,10 +66,10 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), commonFileStore.ClassKind)));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](commonFileStore.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](commonFileStore.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](commonFileStore.ExcludedPerson));
-            jsonObject.Add("file", this.PropertySerializerMap["file"](commonFileStore.File));
-            jsonObject.Add("folder", this.PropertySerializerMap["folder"](commonFileStore.Folder));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](commonFileStore.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](commonFileStore.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("file", this.PropertySerializerMap["file"](commonFileStore.File.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("folder", this.PropertySerializerMap["folder"](commonFileStore.Folder.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](commonFileStore.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](commonFileStore.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](commonFileStore.Name));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var commonFileStore = thing as CommonFileStore;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/CompoundParameterTypeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/CompoundParameterTypeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CompoundParameterTypeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="CompoundParameterTypeSerializer"/> class is to provide a <see cref="CompoundParameterType"/> specific serializer
     /// </summary>
-    public class CompoundParameterTypeSerializer : IThingSerializer
+    public class CompoundParameterTypeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -70,14 +69,14 @@ namespace CDP4JsonSerializer
         private JObject Serialize(CompoundParameterType compoundParameterType)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](compoundParameterType.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](compoundParameterType.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](compoundParameterType.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](compoundParameterType.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), compoundParameterType.ClassKind)));
-            jsonObject.Add("component", this.PropertySerializerMap["component"](compoundParameterType.Component));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](compoundParameterType.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](compoundParameterType.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](compoundParameterType.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](compoundParameterType.HyperLink));
+            jsonObject.Add("component", this.PropertySerializerMap["component"](compoundParameterType.Component.OrderBy(x => x, this.orderedItemComparer)));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](compoundParameterType.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](compoundParameterType.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](compoundParameterType.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](compoundParameterType.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](compoundParameterType.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](compoundParameterType.IsDeprecated));
             jsonObject.Add("isFinalized", this.PropertySerializerMap["isFinalized"](compoundParameterType.IsFinalized));
@@ -106,7 +105,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var compoundParameterType = thing as CompoundParameterType;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ConstantSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ConstantSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ConstantSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ConstantSerializer"/> class is to provide a <see cref="Constant"/> specific serializer
     /// </summary>
-    public class ConstantSerializer : IThingSerializer
+    public class ConstantSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -70,13 +69,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Constant constant)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](constant.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](constant.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](constant.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](constant.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), constant.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](constant.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](constant.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](constant.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](constant.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](constant.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](constant.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](constant.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](constant.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](constant.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](constant.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](constant.ModifiedOn));
@@ -106,7 +105,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var constant = thing as Constant;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ContractChangeNoticeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ContractChangeNoticeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ContractChangeNoticeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ContractChangeNoticeSerializer"/> class is to provide a <see cref="ContractChangeNotice"/> specific serializer
     /// </summary>
-    public class ContractChangeNoticeSerializer : IThingSerializer
+    public class ContractChangeNoticeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -76,26 +75,26 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ContractChangeNotice contractChangeNotice)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](contractChangeNotice.ApprovedBy));
+            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](contractChangeNotice.ApprovedBy.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("author", this.PropertySerializerMap["author"](contractChangeNotice.Author));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](contractChangeNotice.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](contractChangeNotice.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("changeProposal", this.PropertySerializerMap["changeProposal"](contractChangeNotice.ChangeProposal));
             jsonObject.Add("classification", this.PropertySerializerMap["classification"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationClassificationKind), contractChangeNotice.Classification)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), contractChangeNotice.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](contractChangeNotice.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](contractChangeNotice.CreatedOn));
-            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](contractChangeNotice.Discussion));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](contractChangeNotice.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](contractChangeNotice.ExcludedPerson));
+            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](contractChangeNotice.Discussion.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](contractChangeNotice.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](contractChangeNotice.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](contractChangeNotice.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](contractChangeNotice.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](contractChangeNotice.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](contractChangeNotice.Owner));
             jsonObject.Add("primaryAnnotatedThing", this.PropertySerializerMap["primaryAnnotatedThing"](contractChangeNotice.PrimaryAnnotatedThing));
-            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](contractChangeNotice.RelatedThing));
+            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](contractChangeNotice.RelatedThing.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](contractChangeNotice.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](contractChangeNotice.ShortName));
-            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](contractChangeNotice.SourceAnnotation));
+            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](contractChangeNotice.SourceAnnotation.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("status", this.PropertySerializerMap["status"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationStatusKind), contractChangeNotice.Status)));
             jsonObject.Add("title", this.PropertySerializerMap["title"](contractChangeNotice.Title));
             return jsonObject;
@@ -118,7 +117,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var contractChangeNotice = thing as ContractChangeNotice;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/CyclicRatioScaleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/CyclicRatioScaleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CyclicRatioScaleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="CyclicRatioScaleSerializer"/> class is to provide a <see cref="CyclicRatioScale"/> specific serializer
     /// </summary>
-    public class CyclicRatioScaleSerializer : IThingSerializer
+    public class CyclicRatioScaleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -77,17 +76,17 @@ namespace CDP4JsonSerializer
         private JObject Serialize(CyclicRatioScale cyclicRatioScale)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](cyclicRatioScale.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](cyclicRatioScale.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), cyclicRatioScale.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](cyclicRatioScale.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](cyclicRatioScale.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](cyclicRatioScale.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](cyclicRatioScale.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](cyclicRatioScale.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](cyclicRatioScale.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](cyclicRatioScale.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](cyclicRatioScale.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](cyclicRatioScale.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](cyclicRatioScale.IsDeprecated));
             jsonObject.Add("isMaximumInclusive", this.PropertySerializerMap["isMaximumInclusive"](cyclicRatioScale.IsMaximumInclusive));
             jsonObject.Add("isMinimumInclusive", this.PropertySerializerMap["isMinimumInclusive"](cyclicRatioScale.IsMinimumInclusive));
-            jsonObject.Add("mappingToReferenceScale", this.PropertySerializerMap["mappingToReferenceScale"](cyclicRatioScale.MappingToReferenceScale));
+            jsonObject.Add("mappingToReferenceScale", this.PropertySerializerMap["mappingToReferenceScale"](cyclicRatioScale.MappingToReferenceScale.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("maximumPermissibleValue", this.PropertySerializerMap["maximumPermissibleValue"](cyclicRatioScale.MaximumPermissibleValue));
             jsonObject.Add("minimumPermissibleValue", this.PropertySerializerMap["minimumPermissibleValue"](cyclicRatioScale.MinimumPermissibleValue));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](cyclicRatioScale.ModifiedOn));
@@ -99,7 +98,7 @@ namespace CDP4JsonSerializer
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](cyclicRatioScale.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](cyclicRatioScale.ShortName));
             jsonObject.Add("unit", this.PropertySerializerMap["unit"](cyclicRatioScale.Unit));
-            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](cyclicRatioScale.ValueDefinition));
+            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](cyclicRatioScale.ValueDefinition.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -120,7 +119,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var cyclicRatioScale = thing as CyclicRatioScale;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DateParameterTypeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DateParameterTypeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DateParameterTypeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DateParameterTypeSerializer"/> class is to provide a <see cref="DateParameterType"/> specific serializer
     /// </summary>
-    public class DateParameterTypeSerializer : IThingSerializer
+    public class DateParameterTypeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,13 +67,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(DateParameterType dateParameterType)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](dateParameterType.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](dateParameterType.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](dateParameterType.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](dateParameterType.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), dateParameterType.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](dateParameterType.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](dateParameterType.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](dateParameterType.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](dateParameterType.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](dateParameterType.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](dateParameterType.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](dateParameterType.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](dateParameterType.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](dateParameterType.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](dateParameterType.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](dateParameterType.ModifiedOn));
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var dateParameterType = thing as DateParameterType;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DateTimeParameterTypeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DateTimeParameterTypeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeParameterTypeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DateTimeParameterTypeSerializer"/> class is to provide a <see cref="DateTimeParameterType"/> specific serializer
     /// </summary>
-    public class DateTimeParameterTypeSerializer : IThingSerializer
+    public class DateTimeParameterTypeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,13 +67,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(DateTimeParameterType dateTimeParameterType)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](dateTimeParameterType.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](dateTimeParameterType.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](dateTimeParameterType.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](dateTimeParameterType.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), dateTimeParameterType.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](dateTimeParameterType.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](dateTimeParameterType.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](dateTimeParameterType.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](dateTimeParameterType.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](dateTimeParameterType.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](dateTimeParameterType.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](dateTimeParameterType.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](dateTimeParameterType.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](dateTimeParameterType.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](dateTimeParameterType.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](dateTimeParameterType.ModifiedOn));
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var dateTimeParameterType = thing as DateTimeParameterType;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DecompositionRuleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DecompositionRuleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DecompositionRuleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DecompositionRuleSerializer"/> class is to provide a <see cref="DecompositionRule"/> specific serializer
     /// </summary>
-    public class DecompositionRuleSerializer : IThingSerializer
+    public class DecompositionRuleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -70,14 +69,14 @@ namespace CDP4JsonSerializer
         private JObject Serialize(DecompositionRule decompositionRule)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](decompositionRule.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](decompositionRule.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), decompositionRule.ClassKind)));
-            jsonObject.Add("containedCategory", this.PropertySerializerMap["containedCategory"](decompositionRule.ContainedCategory));
+            jsonObject.Add("containedCategory", this.PropertySerializerMap["containedCategory"](decompositionRule.ContainedCategory.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("containingCategory", this.PropertySerializerMap["containingCategory"](decompositionRule.ContainingCategory));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](decompositionRule.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](decompositionRule.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](decompositionRule.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](decompositionRule.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](decompositionRule.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](decompositionRule.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](decompositionRule.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](decompositionRule.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](decompositionRule.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](decompositionRule.IsDeprecated));
             jsonObject.Add("maxContained", this.PropertySerializerMap["maxContained"](decompositionRule.MaxContained));
@@ -106,7 +105,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var decompositionRule = thing as DecompositionRule;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DefinitionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DefinitionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DefinitionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DefinitionSerializer"/> class is to provide a <see cref="Definition"/> specific serializer
     /// </summary>
-    public class DefinitionSerializer : IThingSerializer
+    public class DefinitionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,16 +64,16 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Definition definition)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("citation", this.PropertySerializerMap["citation"](definition.Citation));
+            jsonObject.Add("citation", this.PropertySerializerMap["citation"](definition.Citation.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), definition.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](definition.Content));
-            jsonObject.Add("example", this.PropertySerializerMap["example"](definition.Example));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](definition.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](definition.ExcludedPerson));
+            jsonObject.Add("example", this.PropertySerializerMap["example"](definition.Example.OrderBy(x => x, this.orderedItemComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](definition.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](definition.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](definition.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](definition.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](definition.ModifiedOn));
-            jsonObject.Add("note", this.PropertySerializerMap["note"](definition.Note));
+            jsonObject.Add("note", this.PropertySerializerMap["note"](definition.Note.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](definition.RevisionNumber));
             return jsonObject;
         }
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var definition = thing as Definition;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DerivedQuantityKindSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DerivedQuantityKindSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DerivedQuantityKindSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DerivedQuantityKindSerializer"/> class is to provide a <see cref="DerivedQuantityKind"/> specific serializer
     /// </summary>
-    public class DerivedQuantityKindSerializer : IThingSerializer
+    public class DerivedQuantityKindSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -72,21 +71,21 @@ namespace CDP4JsonSerializer
         private JObject Serialize(DerivedQuantityKind derivedQuantityKind)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](derivedQuantityKind.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](derivedQuantityKind.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](derivedQuantityKind.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](derivedQuantityKind.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), derivedQuantityKind.ClassKind)));
             jsonObject.Add("defaultScale", this.PropertySerializerMap["defaultScale"](derivedQuantityKind.DefaultScale));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](derivedQuantityKind.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](derivedQuantityKind.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](derivedQuantityKind.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](derivedQuantityKind.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](derivedQuantityKind.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](derivedQuantityKind.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](derivedQuantityKind.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](derivedQuantityKind.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](derivedQuantityKind.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](derivedQuantityKind.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](derivedQuantityKind.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](derivedQuantityKind.Name));
-            jsonObject.Add("possibleScale", this.PropertySerializerMap["possibleScale"](derivedQuantityKind.PossibleScale));
+            jsonObject.Add("possibleScale", this.PropertySerializerMap["possibleScale"](derivedQuantityKind.PossibleScale.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("quantityDimensionSymbol", this.PropertySerializerMap["quantityDimensionSymbol"](derivedQuantityKind.QuantityDimensionSymbol));
-            jsonObject.Add("quantityKindFactor", this.PropertySerializerMap["quantityKindFactor"](derivedQuantityKind.QuantityKindFactor));
+            jsonObject.Add("quantityKindFactor", this.PropertySerializerMap["quantityKindFactor"](derivedQuantityKind.QuantityKindFactor.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](derivedQuantityKind.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](derivedQuantityKind.ShortName));
             jsonObject.Add("symbol", this.PropertySerializerMap["symbol"](derivedQuantityKind.Symbol));
@@ -110,7 +109,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var derivedQuantityKind = thing as DerivedQuantityKind;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DerivedUnitSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DerivedUnitSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DerivedUnitSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DerivedUnitSerializer"/> class is to provide a <see cref="DerivedUnit"/> specific serializer
     /// </summary>
-    public class DerivedUnitSerializer : IThingSerializer
+    public class DerivedUnitSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,19 +66,19 @@ namespace CDP4JsonSerializer
         private JObject Serialize(DerivedUnit derivedUnit)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](derivedUnit.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](derivedUnit.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), derivedUnit.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](derivedUnit.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](derivedUnit.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](derivedUnit.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](derivedUnit.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](derivedUnit.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](derivedUnit.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](derivedUnit.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](derivedUnit.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](derivedUnit.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](derivedUnit.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](derivedUnit.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](derivedUnit.Name));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](derivedUnit.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](derivedUnit.ShortName));
-            jsonObject.Add("unitFactor", this.PropertySerializerMap["unitFactor"](derivedUnit.UnitFactor));
+            jsonObject.Add("unitFactor", this.PropertySerializerMap["unitFactor"](derivedUnit.UnitFactor.OrderBy(x => x, this.orderedItemComparer)));
             return jsonObject;
         }
 
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var derivedUnit = thing as DerivedUnit;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DiagramCanvasSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DiagramCanvasSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramCanvasSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DiagramCanvasSerializer"/> class is to provide a <see cref="DiagramCanvas"/> specific serializer
     /// </summary>
-    public class DiagramCanvasSerializer : IThingSerializer
+    public class DiagramCanvasSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,12 +63,12 @@ namespace CDP4JsonSerializer
         private JObject Serialize(DiagramCanvas diagramCanvas)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("bounds", this.PropertySerializerMap["bounds"](diagramCanvas.Bounds));
+            jsonObject.Add("bounds", this.PropertySerializerMap["bounds"](diagramCanvas.Bounds.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), diagramCanvas.ClassKind)));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](diagramCanvas.CreatedOn));
-            jsonObject.Add("diagramElement", this.PropertySerializerMap["diagramElement"](diagramCanvas.DiagramElement));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](diagramCanvas.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](diagramCanvas.ExcludedPerson));
+            jsonObject.Add("diagramElement", this.PropertySerializerMap["diagramElement"](diagramCanvas.DiagramElement.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](diagramCanvas.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](diagramCanvas.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](diagramCanvas.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](diagramCanvas.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](diagramCanvas.Name));
@@ -94,7 +93,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var diagramCanvas = thing as DiagramCanvas;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DiagramEdgeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DiagramEdgeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramEdgeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DiagramEdgeSerializer"/> class is to provide a <see cref="DiagramEdge"/> specific serializer
     /// </summary>
-    public class DiagramEdgeSerializer : IThingSerializer
+    public class DiagramEdgeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -69,17 +68,17 @@ namespace CDP4JsonSerializer
         private JObject Serialize(DiagramEdge diagramEdge)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("bounds", this.PropertySerializerMap["bounds"](diagramEdge.Bounds));
+            jsonObject.Add("bounds", this.PropertySerializerMap["bounds"](diagramEdge.Bounds.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), diagramEdge.ClassKind)));
             jsonObject.Add("depictedThing", this.PropertySerializerMap["depictedThing"](diagramEdge.DepictedThing));
-            jsonObject.Add("diagramElement", this.PropertySerializerMap["diagramElement"](diagramEdge.DiagramElement));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](diagramEdge.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](diagramEdge.ExcludedPerson));
+            jsonObject.Add("diagramElement", this.PropertySerializerMap["diagramElement"](diagramEdge.DiagramElement.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](diagramEdge.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](diagramEdge.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](diagramEdge.Iid));
-            jsonObject.Add("localStyle", this.PropertySerializerMap["localStyle"](diagramEdge.LocalStyle));
+            jsonObject.Add("localStyle", this.PropertySerializerMap["localStyle"](diagramEdge.LocalStyle.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](diagramEdge.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](diagramEdge.Name));
-            jsonObject.Add("point", this.PropertySerializerMap["point"](diagramEdge.Point));
+            jsonObject.Add("point", this.PropertySerializerMap["point"](diagramEdge.Point.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](diagramEdge.RevisionNumber));
             jsonObject.Add("sharedStyle", this.PropertySerializerMap["sharedStyle"](diagramEdge.SharedStyle));
             jsonObject.Add("source", this.PropertySerializerMap["source"](diagramEdge.Source));
@@ -104,7 +103,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var diagramEdge = thing as DiagramEdge;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DiagramObjectSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DiagramObjectSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramObjectSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DiagramObjectSerializer"/> class is to provide a <see cref="DiagramObject"/> specific serializer
     /// </summary>
-    public class DiagramObjectSerializer : IThingSerializer
+    public class DiagramObjectSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,15 +67,15 @@ namespace CDP4JsonSerializer
         private JObject Serialize(DiagramObject diagramObject)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("bounds", this.PropertySerializerMap["bounds"](diagramObject.Bounds));
+            jsonObject.Add("bounds", this.PropertySerializerMap["bounds"](diagramObject.Bounds.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), diagramObject.ClassKind)));
             jsonObject.Add("depictedThing", this.PropertySerializerMap["depictedThing"](diagramObject.DepictedThing));
-            jsonObject.Add("diagramElement", this.PropertySerializerMap["diagramElement"](diagramObject.DiagramElement));
+            jsonObject.Add("diagramElement", this.PropertySerializerMap["diagramElement"](diagramObject.DiagramElement.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("documentation", this.PropertySerializerMap["documentation"](diagramObject.Documentation));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](diagramObject.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](diagramObject.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](diagramObject.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](diagramObject.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](diagramObject.Iid));
-            jsonObject.Add("localStyle", this.PropertySerializerMap["localStyle"](diagramObject.LocalStyle));
+            jsonObject.Add("localStyle", this.PropertySerializerMap["localStyle"](diagramObject.LocalStyle.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](diagramObject.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](diagramObject.Name));
             jsonObject.Add("resolution", this.PropertySerializerMap["resolution"](diagramObject.Resolution));
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var diagramObject = thing as DiagramObject;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DomainFileStoreSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DomainFileStoreSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainFileStoreSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DomainFileStoreSerializer"/> class is to provide a <see cref="DomainFileStore"/> specific serializer
     /// </summary>
-    public class DomainFileStoreSerializer : IThingSerializer
+    public class DomainFileStoreSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,10 +67,10 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), domainFileStore.ClassKind)));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](domainFileStore.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](domainFileStore.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](domainFileStore.ExcludedPerson));
-            jsonObject.Add("file", this.PropertySerializerMap["file"](domainFileStore.File));
-            jsonObject.Add("folder", this.PropertySerializerMap["folder"](domainFileStore.Folder));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](domainFileStore.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](domainFileStore.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("file", this.PropertySerializerMap["file"](domainFileStore.File.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("folder", this.PropertySerializerMap["folder"](domainFileStore.Folder.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](domainFileStore.Iid));
             jsonObject.Add("isHidden", this.PropertySerializerMap["isHidden"](domainFileStore.IsHidden));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](domainFileStore.ModifiedOn));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var domainFileStore = thing as DomainFileStore;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DomainOfExpertiseGroupSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DomainOfExpertiseGroupSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainOfExpertiseGroupSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DomainOfExpertiseGroupSerializer"/> class is to provide a <see cref="DomainOfExpertiseGroup"/> specific serializer
     /// </summary>
-    public class DomainOfExpertiseGroupSerializer : IThingSerializer
+    public class DomainOfExpertiseGroupSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,13 +66,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(DomainOfExpertiseGroup domainOfExpertiseGroup)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](domainOfExpertiseGroup.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](domainOfExpertiseGroup.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), domainOfExpertiseGroup.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](domainOfExpertiseGroup.Definition));
-            jsonObject.Add("domain", this.PropertySerializerMap["domain"](domainOfExpertiseGroup.Domain));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](domainOfExpertiseGroup.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](domainOfExpertiseGroup.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](domainOfExpertiseGroup.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](domainOfExpertiseGroup.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("domain", this.PropertySerializerMap["domain"](domainOfExpertiseGroup.Domain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](domainOfExpertiseGroup.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](domainOfExpertiseGroup.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](domainOfExpertiseGroup.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](domainOfExpertiseGroup.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](domainOfExpertiseGroup.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](domainOfExpertiseGroup.ModifiedOn));
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var domainOfExpertiseGroup = thing as DomainOfExpertiseGroup;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/DomainOfExpertiseSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/DomainOfExpertiseSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainOfExpertiseSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="DomainOfExpertiseSerializer"/> class is to provide a <see cref="DomainOfExpertise"/> specific serializer
     /// </summary>
-    public class DomainOfExpertiseSerializer : IThingSerializer
+    public class DomainOfExpertiseSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,13 +66,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(DomainOfExpertise domainOfExpertise)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](domainOfExpertise.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](domainOfExpertise.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](domainOfExpertise.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](domainOfExpertise.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), domainOfExpertise.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](domainOfExpertise.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](domainOfExpertise.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](domainOfExpertise.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](domainOfExpertise.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](domainOfExpertise.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](domainOfExpertise.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](domainOfExpertise.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](domainOfExpertise.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](domainOfExpertise.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](domainOfExpertise.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](domainOfExpertise.ModifiedOn));
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var domainOfExpertise = thing as DomainOfExpertise;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ElementDefinitionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ElementDefinitionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ElementDefinitionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ElementDefinitionSerializer"/> class is to provide a <see cref="ElementDefinition"/> specific serializer
     /// </summary>
-    public class ElementDefinitionSerializer : IThingSerializer
+    public class ElementDefinitionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,21 +70,21 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ElementDefinition elementDefinition)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](elementDefinition.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](elementDefinition.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](elementDefinition.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](elementDefinition.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), elementDefinition.ClassKind)));
-            jsonObject.Add("containedElement", this.PropertySerializerMap["containedElement"](elementDefinition.ContainedElement));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](elementDefinition.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](elementDefinition.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](elementDefinition.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](elementDefinition.HyperLink));
+            jsonObject.Add("containedElement", this.PropertySerializerMap["containedElement"](elementDefinition.ContainedElement.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](elementDefinition.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](elementDefinition.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](elementDefinition.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](elementDefinition.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](elementDefinition.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](elementDefinition.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](elementDefinition.Name));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](elementDefinition.Owner));
-            jsonObject.Add("parameter", this.PropertySerializerMap["parameter"](elementDefinition.Parameter));
-            jsonObject.Add("parameterGroup", this.PropertySerializerMap["parameterGroup"](elementDefinition.ParameterGroup));
-            jsonObject.Add("referencedElement", this.PropertySerializerMap["referencedElement"](elementDefinition.ReferencedElement));
+            jsonObject.Add("parameter", this.PropertySerializerMap["parameter"](elementDefinition.Parameter.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("parameterGroup", this.PropertySerializerMap["parameterGroup"](elementDefinition.ParameterGroup.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("referencedElement", this.PropertySerializerMap["referencedElement"](elementDefinition.ReferencedElement.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](elementDefinition.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](elementDefinition.ShortName));
             return jsonObject;
@@ -108,7 +107,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var elementDefinition = thing as ElementDefinition;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ElementUsageSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ElementUsageSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ElementUsageSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ElementUsageSerializer"/> class is to provide a <see cref="ElementUsage"/> specific serializer
     /// </summary>
-    public class ElementUsageSerializer : IThingSerializer
+    public class ElementUsageSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,21 +70,21 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ElementUsage elementUsage)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](elementUsage.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](elementUsage.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](elementUsage.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](elementUsage.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), elementUsage.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](elementUsage.Definition));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](elementUsage.Definition.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("elementDefinition", this.PropertySerializerMap["elementDefinition"](elementUsage.ElementDefinition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](elementUsage.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](elementUsage.ExcludedPerson));
-            jsonObject.Add("excludeOption", this.PropertySerializerMap["excludeOption"](elementUsage.ExcludeOption));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](elementUsage.HyperLink));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](elementUsage.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](elementUsage.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludeOption", this.PropertySerializerMap["excludeOption"](elementUsage.ExcludeOption.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](elementUsage.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](elementUsage.Iid));
             jsonObject.Add("interfaceEnd", this.PropertySerializerMap["interfaceEnd"](Enum.GetName(typeof(CDP4Common.EngineeringModelData.InterfaceEndKind), elementUsage.InterfaceEnd)));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](elementUsage.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](elementUsage.Name));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](elementUsage.Owner));
-            jsonObject.Add("parameterOverride", this.PropertySerializerMap["parameterOverride"](elementUsage.ParameterOverride));
+            jsonObject.Add("parameterOverride", this.PropertySerializerMap["parameterOverride"](elementUsage.ParameterOverride.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](elementUsage.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](elementUsage.ShortName));
             return jsonObject;
@@ -108,7 +107,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var elementUsage = thing as ElementUsage;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/EmailAddressSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/EmailAddressSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EmailAddressSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="EmailAddressSerializer"/> class is to provide a <see cref="EmailAddress"/> specific serializer
     /// </summary>
-    public class EmailAddressSerializer : IThingSerializer
+    public class EmailAddressSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,8 +62,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), emailAddress.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](emailAddress.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](emailAddress.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](emailAddress.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](emailAddress.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](emailAddress.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](emailAddress.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](emailAddress.RevisionNumber));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var emailAddress = thing as EmailAddress;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/EngineeringModelDataDiscussionItemSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/EngineeringModelDataDiscussionItemSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelDataDiscussionItemSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="EngineeringModelDataDiscussionItemSerializer"/> class is to provide a <see cref="EngineeringModelDataDiscussionItem"/> specific serializer
     /// </summary>
-    public class EngineeringModelDataDiscussionItemSerializer : IThingSerializer
+    public class EngineeringModelDataDiscussionItemSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -69,8 +68,8 @@ namespace CDP4JsonSerializer
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), engineeringModelDataDiscussionItem.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](engineeringModelDataDiscussionItem.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](engineeringModelDataDiscussionItem.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](engineeringModelDataDiscussionItem.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](engineeringModelDataDiscussionItem.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](engineeringModelDataDiscussionItem.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](engineeringModelDataDiscussionItem.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](engineeringModelDataDiscussionItem.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](engineeringModelDataDiscussionItem.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](engineeringModelDataDiscussionItem.ModifiedOn));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var engineeringModelDataDiscussionItem = thing as EngineeringModelDataDiscussionItem;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/EngineeringModelDataNoteSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/EngineeringModelDataNoteSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelDataNoteSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="EngineeringModelDataNoteSerializer"/> class is to provide a <see cref="EngineeringModelDataNote"/> specific serializer
     /// </summary>
-    public class EngineeringModelDataNoteSerializer : IThingSerializer
+    public class EngineeringModelDataNoteSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,14 +70,14 @@ namespace CDP4JsonSerializer
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), engineeringModelDataNote.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](engineeringModelDataNote.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](engineeringModelDataNote.CreatedOn));
-            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](engineeringModelDataNote.Discussion));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](engineeringModelDataNote.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](engineeringModelDataNote.ExcludedPerson));
+            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](engineeringModelDataNote.Discussion.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](engineeringModelDataNote.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](engineeringModelDataNote.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](engineeringModelDataNote.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](engineeringModelDataNote.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](engineeringModelDataNote.ModifiedOn));
             jsonObject.Add("primaryAnnotatedThing", this.PropertySerializerMap["primaryAnnotatedThing"](engineeringModelDataNote.PrimaryAnnotatedThing));
-            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](engineeringModelDataNote.RelatedThing));
+            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](engineeringModelDataNote.RelatedThing.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](engineeringModelDataNote.RevisionNumber));
             return jsonObject;
         }
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var engineeringModelDataNote = thing as EngineeringModelDataNote;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/EngineeringModelSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/EngineeringModelSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="EngineeringModelSerializer"/> class is to provide a <see cref="EngineeringModel"/> specific serializer
     /// </summary>
-    public class EngineeringModelSerializer : IThingSerializer
+    public class EngineeringModelSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,18 +67,18 @@ namespace CDP4JsonSerializer
         private JObject Serialize(EngineeringModel engineeringModel)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("book", this.PropertySerializerMap["book"](engineeringModel.Book));
+            jsonObject.Add("book", this.PropertySerializerMap["book"](engineeringModel.Book.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), engineeringModel.ClassKind)));
-            jsonObject.Add("commonFileStore", this.PropertySerializerMap["commonFileStore"](engineeringModel.CommonFileStore));
+            jsonObject.Add("commonFileStore", this.PropertySerializerMap["commonFileStore"](engineeringModel.CommonFileStore.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("engineeringModelSetup", this.PropertySerializerMap["engineeringModelSetup"](engineeringModel.EngineeringModelSetup));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](engineeringModel.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](engineeringModel.ExcludedPerson));
-            jsonObject.Add("genericNote", this.PropertySerializerMap["genericNote"](engineeringModel.GenericNote));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](engineeringModel.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](engineeringModel.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("genericNote", this.PropertySerializerMap["genericNote"](engineeringModel.GenericNote.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](engineeringModel.Iid));
-            jsonObject.Add("iteration", this.PropertySerializerMap["iteration"](engineeringModel.Iteration));
+            jsonObject.Add("iteration", this.PropertySerializerMap["iteration"](engineeringModel.Iteration.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("lastModifiedOn", this.PropertySerializerMap["lastModifiedOn"](engineeringModel.LastModifiedOn));
-            jsonObject.Add("logEntry", this.PropertySerializerMap["logEntry"](engineeringModel.LogEntry));
-            jsonObject.Add("modellingAnnotation", this.PropertySerializerMap["modellingAnnotation"](engineeringModel.ModellingAnnotation));
+            jsonObject.Add("logEntry", this.PropertySerializerMap["logEntry"](engineeringModel.LogEntry.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("modellingAnnotation", this.PropertySerializerMap["modellingAnnotation"](engineeringModel.ModellingAnnotation.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](engineeringModel.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](engineeringModel.RevisionNumber));
             return jsonObject;
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var engineeringModel = thing as EngineeringModel;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/EngineeringModelSetupSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/EngineeringModelSetupSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelSetupSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="EngineeringModelSetupSerializer"/> class is to provide a <see cref="EngineeringModelSetup"/> specific serializer
     /// </summary>
-    public class EngineeringModelSetupSerializer : IThingSerializer
+    public class EngineeringModelSetupSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -73,21 +72,21 @@ namespace CDP4JsonSerializer
         private JObject Serialize(EngineeringModelSetup engineeringModelSetup)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("activeDomain", this.PropertySerializerMap["activeDomain"](engineeringModelSetup.ActiveDomain));
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](engineeringModelSetup.Alias));
+            jsonObject.Add("activeDomain", this.PropertySerializerMap["activeDomain"](engineeringModelSetup.ActiveDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](engineeringModelSetup.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), engineeringModelSetup.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](engineeringModelSetup.Definition));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](engineeringModelSetup.Definition.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("engineeringModelIid", this.PropertySerializerMap["engineeringModelIid"](engineeringModelSetup.EngineeringModelIid));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](engineeringModelSetup.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](engineeringModelSetup.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](engineeringModelSetup.HyperLink));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](engineeringModelSetup.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](engineeringModelSetup.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](engineeringModelSetup.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](engineeringModelSetup.Iid));
-            jsonObject.Add("iterationSetup", this.PropertySerializerMap["iterationSetup"](engineeringModelSetup.IterationSetup));
+            jsonObject.Add("iterationSetup", this.PropertySerializerMap["iterationSetup"](engineeringModelSetup.IterationSetup.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("kind", this.PropertySerializerMap["kind"](Enum.GetName(typeof(CDP4Common.SiteDirectoryData.EngineeringModelKind), engineeringModelSetup.Kind)));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](engineeringModelSetup.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](engineeringModelSetup.Name));
-            jsonObject.Add("participant", this.PropertySerializerMap["participant"](engineeringModelSetup.Participant));
-            jsonObject.Add("requiredRdl", this.PropertySerializerMap["requiredRdl"](engineeringModelSetup.RequiredRdl));
+            jsonObject.Add("participant", this.PropertySerializerMap["participant"](engineeringModelSetup.Participant.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("requiredRdl", this.PropertySerializerMap["requiredRdl"](engineeringModelSetup.RequiredRdl.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](engineeringModelSetup.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](engineeringModelSetup.ShortName));
             jsonObject.Add("sourceEngineeringModelSetupIid", this.PropertySerializerMap["sourceEngineeringModelSetupIid"](engineeringModelSetup.SourceEngineeringModelSetupIid));
@@ -112,7 +111,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var engineeringModelSetup = thing as EngineeringModelSetup;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/EnumerationParameterTypeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/EnumerationParameterTypeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EnumerationParameterTypeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="EnumerationParameterTypeSerializer"/> class is to provide a <see cref="EnumerationParameterType"/> specific serializer
     /// </summary>
-    public class EnumerationParameterTypeSerializer : IThingSerializer
+    public class EnumerationParameterTypeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -70,14 +69,14 @@ namespace CDP4JsonSerializer
         private JObject Serialize(EnumerationParameterType enumerationParameterType)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](enumerationParameterType.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](enumerationParameterType.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("allowMultiSelect", this.PropertySerializerMap["allowMultiSelect"](enumerationParameterType.AllowMultiSelect));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](enumerationParameterType.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](enumerationParameterType.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), enumerationParameterType.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](enumerationParameterType.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](enumerationParameterType.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](enumerationParameterType.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](enumerationParameterType.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](enumerationParameterType.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](enumerationParameterType.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](enumerationParameterType.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](enumerationParameterType.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](enumerationParameterType.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](enumerationParameterType.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](enumerationParameterType.ModifiedOn));
@@ -85,7 +84,7 @@ namespace CDP4JsonSerializer
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](enumerationParameterType.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](enumerationParameterType.ShortName));
             jsonObject.Add("symbol", this.PropertySerializerMap["symbol"](enumerationParameterType.Symbol));
-            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](enumerationParameterType.ValueDefinition));
+            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](enumerationParameterType.ValueDefinition.OrderBy(x => x, this.orderedItemComparer)));
             return jsonObject;
         }
 
@@ -106,7 +105,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var enumerationParameterType = thing as EnumerationParameterType;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/EnumerationValueDefinitionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/EnumerationValueDefinitionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EnumerationValueDefinitionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="EnumerationValueDefinitionSerializer"/> class is to provide a <see cref="EnumerationValueDefinition"/> specific serializer
     /// </summary>
-    public class EnumerationValueDefinitionSerializer : IThingSerializer
+    public class EnumerationValueDefinitionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,12 +64,12 @@ namespace CDP4JsonSerializer
         private JObject Serialize(EnumerationValueDefinition enumerationValueDefinition)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](enumerationValueDefinition.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](enumerationValueDefinition.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), enumerationValueDefinition.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](enumerationValueDefinition.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](enumerationValueDefinition.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](enumerationValueDefinition.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](enumerationValueDefinition.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](enumerationValueDefinition.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](enumerationValueDefinition.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](enumerationValueDefinition.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](enumerationValueDefinition.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](enumerationValueDefinition.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](enumerationValueDefinition.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](enumerationValueDefinition.Name));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var enumerationValueDefinition = thing as EnumerationValueDefinition;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ExclusiveOrExpressionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ExclusiveOrExpressionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ExclusiveOrExpressionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ExclusiveOrExpressionSerializer"/> class is to provide a <see cref="ExclusiveOrExpression"/> specific serializer
     /// </summary>
-    public class ExclusiveOrExpressionSerializer : IThingSerializer
+    public class ExclusiveOrExpressionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -62,12 +61,12 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), exclusiveOrExpression.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](exclusiveOrExpression.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](exclusiveOrExpression.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](exclusiveOrExpression.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](exclusiveOrExpression.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](exclusiveOrExpression.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](exclusiveOrExpression.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](exclusiveOrExpression.RevisionNumber));
-            jsonObject.Add("term", this.PropertySerializerMap["term"](exclusiveOrExpression.Term));
+            jsonObject.Add("term", this.PropertySerializerMap["term"](exclusiveOrExpression.Term.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -88,7 +87,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var exclusiveOrExpression = thing as ExclusiveOrExpression;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ExternalIdentifierMapSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ExternalIdentifierMapSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ExternalIdentifierMapSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ExternalIdentifierMapSerializer"/> class is to provide a <see cref="ExternalIdentifierMap"/> specific serializer
     /// </summary>
-    public class ExternalIdentifierMapSerializer : IThingSerializer
+    public class ExternalIdentifierMapSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,9 +67,9 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), externalIdentifierMap.ClassKind)));
-            jsonObject.Add("correspondence", this.PropertySerializerMap["correspondence"](externalIdentifierMap.Correspondence));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](externalIdentifierMap.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](externalIdentifierMap.ExcludedPerson));
+            jsonObject.Add("correspondence", this.PropertySerializerMap["correspondence"](externalIdentifierMap.Correspondence.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](externalIdentifierMap.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](externalIdentifierMap.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("externalFormat", this.PropertySerializerMap["externalFormat"](externalIdentifierMap.ExternalFormat));
             jsonObject.Add("externalModelName", this.PropertySerializerMap["externalModelName"](externalIdentifierMap.ExternalModelName));
             jsonObject.Add("externalToolName", this.PropertySerializerMap["externalToolName"](externalIdentifierMap.ExternalToolName));
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var externalIdentifierMap = thing as ExternalIdentifierMap;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/FileRevisionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/FileRevisionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FileRevisionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="FileRevisionSerializer"/> class is to provide a <see cref="FileRevision"/> specific serializer
     /// </summary>
-    public class FileRevisionSerializer : IThingSerializer
+    public class FileRevisionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,9 +70,9 @@ namespace CDP4JsonSerializer
             jsonObject.Add("contentHash", this.PropertySerializerMap["contentHash"](fileRevision.ContentHash));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](fileRevision.CreatedOn));
             jsonObject.Add("creator", this.PropertySerializerMap["creator"](fileRevision.Creator));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](fileRevision.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](fileRevision.ExcludedPerson));
-            jsonObject.Add("fileType", this.PropertySerializerMap["fileType"](fileRevision.FileType));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](fileRevision.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](fileRevision.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("fileType", this.PropertySerializerMap["fileType"](fileRevision.FileType.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](fileRevision.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](fileRevision.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](fileRevision.Name));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var fileRevision = thing as FileRevision;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/FileSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/FileSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FileSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="FileSerializer"/> class is to provide a <see cref="File"/> specific serializer
     /// </summary>
-    public class FileSerializer : IThingSerializer
+    public class FileSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,11 +63,11 @@ namespace CDP4JsonSerializer
         private JObject Serialize(File file)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("category", this.PropertySerializerMap["category"](file.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](file.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), file.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](file.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](file.ExcludedPerson));
-            jsonObject.Add("fileRevision", this.PropertySerializerMap["fileRevision"](file.FileRevision));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](file.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](file.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("fileRevision", this.PropertySerializerMap["fileRevision"](file.FileRevision.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](file.Iid));
             jsonObject.Add("lockedBy", this.PropertySerializerMap["lockedBy"](file.LockedBy));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](file.ModifiedOn));
@@ -94,7 +93,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var file = thing as File;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/FileTypeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/FileTypeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FileTypeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="FileTypeSerializer"/> class is to provide a <see cref="FileType"/> specific serializer
     /// </summary>
-    public class FileTypeSerializer : IThingSerializer
+    public class FileTypeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,14 +67,14 @@ namespace CDP4JsonSerializer
         private JObject Serialize(FileType fileType)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](fileType.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](fileType.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](fileType.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](fileType.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), fileType.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](fileType.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](fileType.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](fileType.ExcludedPerson));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](fileType.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](fileType.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](fileType.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("extension", this.PropertySerializerMap["extension"](fileType.Extension));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](fileType.HyperLink));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](fileType.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](fileType.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](fileType.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](fileType.ModifiedOn));
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var fileType = thing as FileType;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/FolderSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/FolderSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FolderSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="FolderSerializer"/> class is to provide a <see cref="Folder"/> specific serializer
     /// </summary>
-    public class FolderSerializer : IThingSerializer
+    public class FolderSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -69,8 +68,8 @@ namespace CDP4JsonSerializer
             jsonObject.Add("containingFolder", this.PropertySerializerMap["containingFolder"](folder.ContainingFolder));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](folder.CreatedOn));
             jsonObject.Add("creator", this.PropertySerializerMap["creator"](folder.Creator));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](folder.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](folder.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](folder.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](folder.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](folder.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](folder.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](folder.Name));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var folder = thing as Folder;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/GlossarySerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/GlossarySerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="GlossarySerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="GlossarySerializer"/> class is to provide a <see cref="Glossary"/> specific serializer
     /// </summary>
-    public class GlossarySerializer : IThingSerializer
+    public class GlossarySerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,20 +67,20 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Glossary glossary)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](glossary.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](glossary.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](glossary.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](glossary.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), glossary.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](glossary.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](glossary.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](glossary.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](glossary.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](glossary.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](glossary.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](glossary.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](glossary.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](glossary.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](glossary.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](glossary.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](glossary.Name));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](glossary.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](glossary.ShortName));
-            jsonObject.Add("term", this.PropertySerializerMap["term"](glossary.Term));
+            jsonObject.Add("term", this.PropertySerializerMap["term"](glossary.Term.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var glossary = thing as Glossary;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/GoalSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/GoalSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="GoalSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="GoalSerializer"/> class is to provide a <see cref="Goal"/> specific serializer
     /// </summary>
-    public class GoalSerializer : IThingSerializer
+    public class GoalSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,13 +65,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Goal goal)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](goal.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](goal.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](goal.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](goal.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), goal.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](goal.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](goal.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](goal.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](goal.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](goal.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](goal.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](goal.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](goal.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](goal.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](goal.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](goal.Name));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var goal = thing as Goal;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/HyperLinkSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/HyperLinkSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="HyperLinkSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="HyperLinkSerializer"/> class is to provide a <see cref="HyperLink"/> specific serializer
     /// </summary>
-    public class HyperLinkSerializer : IThingSerializer
+    public class HyperLinkSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,8 +64,8 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), hyperLink.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](hyperLink.Content));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](hyperLink.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](hyperLink.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](hyperLink.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](hyperLink.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](hyperLink.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](hyperLink.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](hyperLink.ModifiedOn));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var hyperLink = thing as HyperLink;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/IdCorrespondenceSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/IdCorrespondenceSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IdCorrespondenceSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="IdCorrespondenceSerializer"/> class is to provide a <see cref="IdCorrespondence"/> specific serializer
     /// </summary>
-    public class IdCorrespondenceSerializer : IThingSerializer
+    public class IdCorrespondenceSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,8 +62,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), idCorrespondence.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](idCorrespondence.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](idCorrespondence.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](idCorrespondence.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](idCorrespondence.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("externalId", this.PropertySerializerMap["externalId"](idCorrespondence.ExternalId));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](idCorrespondence.Iid));
             jsonObject.Add("internalThing", this.PropertySerializerMap["internalThing"](idCorrespondence.InternalThing));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var idCorrespondence = thing as IdCorrespondence;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/IntervalScaleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/IntervalScaleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IntervalScaleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="IntervalScaleSerializer"/> class is to provide a <see cref="IntervalScale"/> specific serializer
     /// </summary>
-    public class IntervalScaleSerializer : IThingSerializer
+    public class IntervalScaleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -76,17 +75,17 @@ namespace CDP4JsonSerializer
         private JObject Serialize(IntervalScale intervalScale)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](intervalScale.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](intervalScale.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), intervalScale.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](intervalScale.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](intervalScale.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](intervalScale.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](intervalScale.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](intervalScale.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](intervalScale.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](intervalScale.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](intervalScale.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](intervalScale.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](intervalScale.IsDeprecated));
             jsonObject.Add("isMaximumInclusive", this.PropertySerializerMap["isMaximumInclusive"](intervalScale.IsMaximumInclusive));
             jsonObject.Add("isMinimumInclusive", this.PropertySerializerMap["isMinimumInclusive"](intervalScale.IsMinimumInclusive));
-            jsonObject.Add("mappingToReferenceScale", this.PropertySerializerMap["mappingToReferenceScale"](intervalScale.MappingToReferenceScale));
+            jsonObject.Add("mappingToReferenceScale", this.PropertySerializerMap["mappingToReferenceScale"](intervalScale.MappingToReferenceScale.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("maximumPermissibleValue", this.PropertySerializerMap["maximumPermissibleValue"](intervalScale.MaximumPermissibleValue));
             jsonObject.Add("minimumPermissibleValue", this.PropertySerializerMap["minimumPermissibleValue"](intervalScale.MinimumPermissibleValue));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](intervalScale.ModifiedOn));
@@ -97,7 +96,7 @@ namespace CDP4JsonSerializer
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](intervalScale.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](intervalScale.ShortName));
             jsonObject.Add("unit", this.PropertySerializerMap["unit"](intervalScale.Unit));
-            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](intervalScale.ValueDefinition));
+            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](intervalScale.ValueDefinition.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -118,7 +117,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var intervalScale = thing as IntervalScale;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/IterationSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/IterationSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IterationSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="IterationSerializer"/> class is to provide a <see cref="Iteration"/> specific serializer
     /// </summary>
-    public class IterationSerializer : IThingSerializer
+    public class IterationSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -81,33 +80,33 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Iteration iteration)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("actualFiniteStateList", this.PropertySerializerMap["actualFiniteStateList"](iteration.ActualFiniteStateList));
+            jsonObject.Add("actualFiniteStateList", this.PropertySerializerMap["actualFiniteStateList"](iteration.ActualFiniteStateList.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), iteration.ClassKind)));
             jsonObject.Add("defaultOption", this.PropertySerializerMap["defaultOption"](iteration.DefaultOption));
-            jsonObject.Add("diagramCanvas", this.PropertySerializerMap["diagramCanvas"](iteration.DiagramCanvas));
-            jsonObject.Add("domainFileStore", this.PropertySerializerMap["domainFileStore"](iteration.DomainFileStore));
-            jsonObject.Add("element", this.PropertySerializerMap["element"](iteration.Element));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](iteration.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](iteration.ExcludedPerson));
-            jsonObject.Add("externalIdentifierMap", this.PropertySerializerMap["externalIdentifierMap"](iteration.ExternalIdentifierMap));
-            jsonObject.Add("goal", this.PropertySerializerMap["goal"](iteration.Goal));
+            jsonObject.Add("diagramCanvas", this.PropertySerializerMap["diagramCanvas"](iteration.DiagramCanvas.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("domainFileStore", this.PropertySerializerMap["domainFileStore"](iteration.DomainFileStore.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("element", this.PropertySerializerMap["element"](iteration.Element.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](iteration.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](iteration.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("externalIdentifierMap", this.PropertySerializerMap["externalIdentifierMap"](iteration.ExternalIdentifierMap.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("goal", this.PropertySerializerMap["goal"](iteration.Goal.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](iteration.Iid));
             jsonObject.Add("iterationSetup", this.PropertySerializerMap["iterationSetup"](iteration.IterationSetup));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](iteration.ModifiedOn));
-            jsonObject.Add("option", this.PropertySerializerMap["option"](iteration.Option));
-            jsonObject.Add("possibleFiniteStateList", this.PropertySerializerMap["possibleFiniteStateList"](iteration.PossibleFiniteStateList));
-            jsonObject.Add("publication", this.PropertySerializerMap["publication"](iteration.Publication));
-            jsonObject.Add("relationship", this.PropertySerializerMap["relationship"](iteration.Relationship));
-            jsonObject.Add("requirementsSpecification", this.PropertySerializerMap["requirementsSpecification"](iteration.RequirementsSpecification));
+            jsonObject.Add("option", this.PropertySerializerMap["option"](iteration.Option.OrderBy(x => x, this.orderedItemComparer)));
+            jsonObject.Add("possibleFiniteStateList", this.PropertySerializerMap["possibleFiniteStateList"](iteration.PossibleFiniteStateList.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("publication", this.PropertySerializerMap["publication"](iteration.Publication.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("relationship", this.PropertySerializerMap["relationship"](iteration.Relationship.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("requirementsSpecification", this.PropertySerializerMap["requirementsSpecification"](iteration.RequirementsSpecification.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](iteration.RevisionNumber));
-            jsonObject.Add("ruleVerificationList", this.PropertySerializerMap["ruleVerificationList"](iteration.RuleVerificationList));
-            jsonObject.Add("sharedDiagramStyle", this.PropertySerializerMap["sharedDiagramStyle"](iteration.SharedDiagramStyle));
+            jsonObject.Add("ruleVerificationList", this.PropertySerializerMap["ruleVerificationList"](iteration.RuleVerificationList.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("sharedDiagramStyle", this.PropertySerializerMap["sharedDiagramStyle"](iteration.SharedDiagramStyle.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("sourceIterationIid", this.PropertySerializerMap["sourceIterationIid"](iteration.SourceIterationIid));
-            jsonObject.Add("stakeholder", this.PropertySerializerMap["stakeholder"](iteration.Stakeholder));
-            jsonObject.Add("stakeholderValue", this.PropertySerializerMap["stakeholderValue"](iteration.StakeholderValue));
-            jsonObject.Add("stakeholderValueMap", this.PropertySerializerMap["stakeholderValueMap"](iteration.StakeholderValueMap));
+            jsonObject.Add("stakeholder", this.PropertySerializerMap["stakeholder"](iteration.Stakeholder.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("stakeholderValue", this.PropertySerializerMap["stakeholderValue"](iteration.StakeholderValue.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("stakeholderValueMap", this.PropertySerializerMap["stakeholderValueMap"](iteration.StakeholderValueMap.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("topElement", this.PropertySerializerMap["topElement"](iteration.TopElement));
-            jsonObject.Add("valueGroup", this.PropertySerializerMap["valueGroup"](iteration.ValueGroup));
+            jsonObject.Add("valueGroup", this.PropertySerializerMap["valueGroup"](iteration.ValueGroup.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -128,7 +127,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var iteration = thing as Iteration;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/IterationSetupSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/IterationSetupSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IterationSetupSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="IterationSetupSerializer"/> class is to provide a <see cref="IterationSetup"/> specific serializer
     /// </summary>
-    public class IterationSetupSerializer : IThingSerializer
+    public class IterationSetupSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -70,8 +69,8 @@ namespace CDP4JsonSerializer
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), iterationSetup.ClassKind)));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](iterationSetup.CreatedOn));
             jsonObject.Add("description", this.PropertySerializerMap["description"](iterationSetup.Description));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](iterationSetup.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](iterationSetup.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](iterationSetup.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](iterationSetup.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("frozenOn", this.PropertySerializerMap["frozenOn"](iterationSetup.FrozenOn));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](iterationSetup.Iid));
             jsonObject.Add("isDeleted", this.PropertySerializerMap["isDeleted"](iterationSetup.IsDeleted));
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var iterationSetup = thing as IterationSetup;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/LinearConversionUnitSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/LinearConversionUnitSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="LinearConversionUnitSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="LinearConversionUnitSerializer"/> class is to provide a <see cref="LinearConversionUnit"/> specific serializer
     /// </summary>
-    public class LinearConversionUnitSerializer : IThingSerializer
+    public class LinearConversionUnitSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,13 +67,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(LinearConversionUnit linearConversionUnit)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](linearConversionUnit.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](linearConversionUnit.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), linearConversionUnit.ClassKind)));
             jsonObject.Add("conversionFactor", this.PropertySerializerMap["conversionFactor"](linearConversionUnit.ConversionFactor));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](linearConversionUnit.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](linearConversionUnit.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](linearConversionUnit.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](linearConversionUnit.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](linearConversionUnit.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](linearConversionUnit.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](linearConversionUnit.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](linearConversionUnit.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](linearConversionUnit.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](linearConversionUnit.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](linearConversionUnit.ModifiedOn));
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var linearConversionUnit = thing as LinearConversionUnit;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/LogarithmicScaleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/LogarithmicScaleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="LogarithmicScaleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="LogarithmicScaleSerializer"/> class is to provide a <see cref="LogarithmicScale"/> specific serializer
     /// </summary>
-    public class LogarithmicScaleSerializer : IThingSerializer
+    public class LogarithmicScaleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -81,20 +80,20 @@ namespace CDP4JsonSerializer
         private JObject Serialize(LogarithmicScale logarithmicScale)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](logarithmicScale.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](logarithmicScale.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), logarithmicScale.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](logarithmicScale.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](logarithmicScale.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](logarithmicScale.ExcludedPerson));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](logarithmicScale.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](logarithmicScale.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](logarithmicScale.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("exponent", this.PropertySerializerMap["exponent"](logarithmicScale.Exponent));
             jsonObject.Add("factor", this.PropertySerializerMap["factor"](logarithmicScale.Factor));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](logarithmicScale.HyperLink));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](logarithmicScale.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](logarithmicScale.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](logarithmicScale.IsDeprecated));
             jsonObject.Add("isMaximumInclusive", this.PropertySerializerMap["isMaximumInclusive"](logarithmicScale.IsMaximumInclusive));
             jsonObject.Add("isMinimumInclusive", this.PropertySerializerMap["isMinimumInclusive"](logarithmicScale.IsMinimumInclusive));
             jsonObject.Add("logarithmBase", this.PropertySerializerMap["logarithmBase"](Enum.GetName(typeof(CDP4Common.SiteDirectoryData.LogarithmBaseKind), logarithmicScale.LogarithmBase)));
-            jsonObject.Add("mappingToReferenceScale", this.PropertySerializerMap["mappingToReferenceScale"](logarithmicScale.MappingToReferenceScale));
+            jsonObject.Add("mappingToReferenceScale", this.PropertySerializerMap["mappingToReferenceScale"](logarithmicScale.MappingToReferenceScale.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("maximumPermissibleValue", this.PropertySerializerMap["maximumPermissibleValue"](logarithmicScale.MaximumPermissibleValue));
             jsonObject.Add("minimumPermissibleValue", this.PropertySerializerMap["minimumPermissibleValue"](logarithmicScale.MinimumPermissibleValue));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](logarithmicScale.ModifiedOn));
@@ -103,11 +102,11 @@ namespace CDP4JsonSerializer
             jsonObject.Add("numberSet", this.PropertySerializerMap["numberSet"](Enum.GetName(typeof(CDP4Common.SiteDirectoryData.NumberSetKind), logarithmicScale.NumberSet)));
             jsonObject.Add("positiveValueConnotation", this.PropertySerializerMap["positiveValueConnotation"](logarithmicScale.PositiveValueConnotation));
             jsonObject.Add("referenceQuantityKind", this.PropertySerializerMap["referenceQuantityKind"](logarithmicScale.ReferenceQuantityKind));
-            jsonObject.Add("referenceQuantityValue", this.PropertySerializerMap["referenceQuantityValue"](logarithmicScale.ReferenceQuantityValue));
+            jsonObject.Add("referenceQuantityValue", this.PropertySerializerMap["referenceQuantityValue"](logarithmicScale.ReferenceQuantityValue.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](logarithmicScale.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](logarithmicScale.ShortName));
             jsonObject.Add("unit", this.PropertySerializerMap["unit"](logarithmicScale.Unit));
-            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](logarithmicScale.ValueDefinition));
+            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](logarithmicScale.ValueDefinition.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -128,7 +127,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var logarithmicScale = thing as LogarithmicScale;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/MappingToReferenceScaleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/MappingToReferenceScaleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MappingToReferenceScaleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="MappingToReferenceScaleSerializer"/> class is to provide a <see cref="MappingToReferenceScale"/> specific serializer
     /// </summary>
-    public class MappingToReferenceScaleSerializer : IThingSerializer
+    public class MappingToReferenceScaleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), mappingToReferenceScale.ClassKind)));
             jsonObject.Add("dependentScaleValue", this.PropertySerializerMap["dependentScaleValue"](mappingToReferenceScale.DependentScaleValue));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](mappingToReferenceScale.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](mappingToReferenceScale.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](mappingToReferenceScale.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](mappingToReferenceScale.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](mappingToReferenceScale.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](mappingToReferenceScale.ModifiedOn));
             jsonObject.Add("referenceScaleValue", this.PropertySerializerMap["referenceScaleValue"](mappingToReferenceScale.ReferenceScaleValue));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var mappingToReferenceScale = thing as MappingToReferenceScale;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ModelLogEntrySerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ModelLogEntrySerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModelLogEntrySerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ModelLogEntrySerializer"/> class is to provide a <see cref="ModelLogEntry"/> specific serializer
     /// </summary>
-    public class ModelLogEntrySerializer : IThingSerializer
+    public class ModelLogEntrySerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,14 +66,14 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ModelLogEntry modelLogEntry)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("affectedItemIid", this.PropertySerializerMap["affectedItemIid"](modelLogEntry.AffectedItemIid));
+            jsonObject.Add("affectedItemIid", this.PropertySerializerMap["affectedItemIid"](modelLogEntry.AffectedItemIid.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("author", this.PropertySerializerMap["author"](modelLogEntry.Author));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](modelLogEntry.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](modelLogEntry.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), modelLogEntry.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](modelLogEntry.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](modelLogEntry.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](modelLogEntry.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](modelLogEntry.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](modelLogEntry.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](modelLogEntry.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](modelLogEntry.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](modelLogEntry.LanguageCode));
             jsonObject.Add("level", this.PropertySerializerMap["level"](Enum.GetName(typeof(CDP4Common.CommonData.LogLevelKind), modelLogEntry.Level)));
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var modelLogEntry = thing as ModelLogEntry;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ModelReferenceDataLibrarySerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ModelReferenceDataLibrarySerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModelReferenceDataLibrarySerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ModelReferenceDataLibrarySerializer"/> class is to provide a <see cref="ModelReferenceDataLibrary"/> specific serializer
     /// </summary>
-    public class ModelReferenceDataLibrarySerializer : IThingSerializer
+    public class ModelReferenceDataLibrarySerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -78,30 +77,30 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ModelReferenceDataLibrary modelReferenceDataLibrary)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](modelReferenceDataLibrary.Alias));
-            jsonObject.Add("baseQuantityKind", this.PropertySerializerMap["baseQuantityKind"](modelReferenceDataLibrary.BaseQuantityKind));
-            jsonObject.Add("baseUnit", this.PropertySerializerMap["baseUnit"](modelReferenceDataLibrary.BaseUnit));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](modelReferenceDataLibrary.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("baseQuantityKind", this.PropertySerializerMap["baseQuantityKind"](modelReferenceDataLibrary.BaseQuantityKind.OrderBy(x => x, this.orderedItemComparer)));
+            jsonObject.Add("baseUnit", this.PropertySerializerMap["baseUnit"](modelReferenceDataLibrary.BaseUnit.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), modelReferenceDataLibrary.ClassKind)));
-            jsonObject.Add("constant", this.PropertySerializerMap["constant"](modelReferenceDataLibrary.Constant));
-            jsonObject.Add("definedCategory", this.PropertySerializerMap["definedCategory"](modelReferenceDataLibrary.DefinedCategory));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](modelReferenceDataLibrary.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](modelReferenceDataLibrary.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](modelReferenceDataLibrary.ExcludedPerson));
-            jsonObject.Add("fileType", this.PropertySerializerMap["fileType"](modelReferenceDataLibrary.FileType));
-            jsonObject.Add("glossary", this.PropertySerializerMap["glossary"](modelReferenceDataLibrary.Glossary));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](modelReferenceDataLibrary.HyperLink));
+            jsonObject.Add("constant", this.PropertySerializerMap["constant"](modelReferenceDataLibrary.Constant.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("definedCategory", this.PropertySerializerMap["definedCategory"](modelReferenceDataLibrary.DefinedCategory.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](modelReferenceDataLibrary.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](modelReferenceDataLibrary.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](modelReferenceDataLibrary.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("fileType", this.PropertySerializerMap["fileType"](modelReferenceDataLibrary.FileType.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("glossary", this.PropertySerializerMap["glossary"](modelReferenceDataLibrary.Glossary.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](modelReferenceDataLibrary.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](modelReferenceDataLibrary.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](modelReferenceDataLibrary.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](modelReferenceDataLibrary.Name));
-            jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](modelReferenceDataLibrary.ParameterType));
-            jsonObject.Add("referenceSource", this.PropertySerializerMap["referenceSource"](modelReferenceDataLibrary.ReferenceSource));
+            jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](modelReferenceDataLibrary.ParameterType.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("referenceSource", this.PropertySerializerMap["referenceSource"](modelReferenceDataLibrary.ReferenceSource.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("requiredRdl", this.PropertySerializerMap["requiredRdl"](modelReferenceDataLibrary.RequiredRdl));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](modelReferenceDataLibrary.RevisionNumber));
-            jsonObject.Add("rule", this.PropertySerializerMap["rule"](modelReferenceDataLibrary.Rule));
-            jsonObject.Add("scale", this.PropertySerializerMap["scale"](modelReferenceDataLibrary.Scale));
+            jsonObject.Add("rule", this.PropertySerializerMap["rule"](modelReferenceDataLibrary.Rule.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("scale", this.PropertySerializerMap["scale"](modelReferenceDataLibrary.Scale.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](modelReferenceDataLibrary.ShortName));
-            jsonObject.Add("unit", this.PropertySerializerMap["unit"](modelReferenceDataLibrary.Unit));
-            jsonObject.Add("unitPrefix", this.PropertySerializerMap["unitPrefix"](modelReferenceDataLibrary.UnitPrefix));
+            jsonObject.Add("unit", this.PropertySerializerMap["unit"](modelReferenceDataLibrary.Unit.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("unitPrefix", this.PropertySerializerMap["unitPrefix"](modelReferenceDataLibrary.UnitPrefix.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -122,7 +121,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var modelReferenceDataLibrary = thing as ModelReferenceDataLibrary;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ModellingThingReferenceSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ModellingThingReferenceSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModellingThingReferenceSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ModellingThingReferenceSerializer"/> class is to provide a <see cref="ModellingThingReference"/> specific serializer
     /// </summary>
-    public class ModellingThingReferenceSerializer : IThingSerializer
+    public class ModellingThingReferenceSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,8 +62,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), modellingThingReference.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](modellingThingReference.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](modellingThingReference.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](modellingThingReference.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](modellingThingReference.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](modellingThingReference.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](modellingThingReference.ModifiedOn));
             jsonObject.Add("referencedRevisionNumber", this.PropertySerializerMap["referencedRevisionNumber"](modellingThingReference.ReferencedRevisionNumber));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var modellingThingReference = thing as ModellingThingReference;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/MultiRelationshipRuleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/MultiRelationshipRuleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MultiRelationshipRuleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="MultiRelationshipRuleSerializer"/> class is to provide a <see cref="MultiRelationshipRule"/> specific serializer
     /// </summary>
-    public class MultiRelationshipRuleSerializer : IThingSerializer
+    public class MultiRelationshipRuleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -70,19 +69,19 @@ namespace CDP4JsonSerializer
         private JObject Serialize(MultiRelationshipRule multiRelationshipRule)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](multiRelationshipRule.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](multiRelationshipRule.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), multiRelationshipRule.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](multiRelationshipRule.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](multiRelationshipRule.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](multiRelationshipRule.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](multiRelationshipRule.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](multiRelationshipRule.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](multiRelationshipRule.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](multiRelationshipRule.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](multiRelationshipRule.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](multiRelationshipRule.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](multiRelationshipRule.IsDeprecated));
             jsonObject.Add("maxRelated", this.PropertySerializerMap["maxRelated"](multiRelationshipRule.MaxRelated));
             jsonObject.Add("minRelated", this.PropertySerializerMap["minRelated"](multiRelationshipRule.MinRelated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](multiRelationshipRule.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](multiRelationshipRule.Name));
-            jsonObject.Add("relatedCategory", this.PropertySerializerMap["relatedCategory"](multiRelationshipRule.RelatedCategory));
+            jsonObject.Add("relatedCategory", this.PropertySerializerMap["relatedCategory"](multiRelationshipRule.RelatedCategory.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("relationshipCategory", this.PropertySerializerMap["relationshipCategory"](multiRelationshipRule.RelationshipCategory));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](multiRelationshipRule.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](multiRelationshipRule.ShortName));
@@ -106,7 +105,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var multiRelationshipRule = thing as MultiRelationshipRule;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/MultiRelationshipSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/MultiRelationshipSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MultiRelationshipSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="MultiRelationshipSerializer"/> class is to provide a <see cref="MultiRelationship"/> specific serializer
     /// </summary>
-    public class MultiRelationshipSerializer : IThingSerializer
+    public class MultiRelationshipSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,15 +63,15 @@ namespace CDP4JsonSerializer
         private JObject Serialize(MultiRelationship multiRelationship)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("category", this.PropertySerializerMap["category"](multiRelationship.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](multiRelationship.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), multiRelationship.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](multiRelationship.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](multiRelationship.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](multiRelationship.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](multiRelationship.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](multiRelationship.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](multiRelationship.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](multiRelationship.Owner));
-            jsonObject.Add("parameterValue", this.PropertySerializerMap["parameterValue"](multiRelationship.ParameterValue));
-            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](multiRelationship.RelatedThing));
+            jsonObject.Add("parameterValue", this.PropertySerializerMap["parameterValue"](multiRelationship.ParameterValue.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](multiRelationship.RelatedThing.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](multiRelationship.RevisionNumber));
             return jsonObject;
         }
@@ -94,7 +93,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var multiRelationship = thing as MultiRelationship;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/NaturalLanguageSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/NaturalLanguageSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NaturalLanguageSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="NaturalLanguageSerializer"/> class is to provide a <see cref="NaturalLanguage"/> specific serializer
     /// </summary>
-    public class NaturalLanguageSerializer : IThingSerializer
+    public class NaturalLanguageSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), naturalLanguage.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](naturalLanguage.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](naturalLanguage.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](naturalLanguage.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](naturalLanguage.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](naturalLanguage.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](naturalLanguage.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](naturalLanguage.ModifiedOn));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var naturalLanguage = thing as NaturalLanguage;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/NestedElementSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/NestedElementSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NestedElementSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="NestedElementSerializer"/> class is to provide a <see cref="NestedElement"/> specific serializer
     /// </summary>
-    public class NestedElementSerializer : IThingSerializer
+    public class NestedElementSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,13 +64,13 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), nestedElement.ClassKind)));
-            jsonObject.Add("elementUsage", this.PropertySerializerMap["elementUsage"](nestedElement.ElementUsage));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](nestedElement.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](nestedElement.ExcludedPerson));
+            jsonObject.Add("elementUsage", this.PropertySerializerMap["elementUsage"](nestedElement.ElementUsage.OrderBy(x => x, this.orderedItemComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](nestedElement.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](nestedElement.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](nestedElement.Iid));
             jsonObject.Add("isVolatile", this.PropertySerializerMap["isVolatile"](nestedElement.IsVolatile));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](nestedElement.ModifiedOn));
-            jsonObject.Add("nestedParameter", this.PropertySerializerMap["nestedParameter"](nestedElement.NestedParameter));
+            jsonObject.Add("nestedParameter", this.PropertySerializerMap["nestedParameter"](nestedElement.NestedParameter.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](nestedElement.RevisionNumber));
             jsonObject.Add("rootElement", this.PropertySerializerMap["rootElement"](nestedElement.RootElement));
             return jsonObject;
@@ -94,7 +93,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var nestedElement = thing as NestedElement;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/NestedParameterSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/NestedParameterSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NestedParameterSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="NestedParameterSerializer"/> class is to provide a <see cref="NestedParameter"/> specific serializer
     /// </summary>
-    public class NestedParameterSerializer : IThingSerializer
+    public class NestedParameterSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -70,8 +69,8 @@ namespace CDP4JsonSerializer
             jsonObject.Add("actualValue", this.PropertySerializerMap["actualValue"](nestedParameter.ActualValue));
             jsonObject.Add("associatedParameter", this.PropertySerializerMap["associatedParameter"](nestedParameter.AssociatedParameter));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), nestedParameter.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](nestedParameter.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](nestedParameter.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](nestedParameter.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](nestedParameter.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("formula", this.PropertySerializerMap["formula"](nestedParameter.Formula));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](nestedParameter.Iid));
             jsonObject.Add("isVolatile", this.PropertySerializerMap["isVolatile"](nestedParameter.IsVolatile));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var nestedParameter = thing as NestedParameter;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/NotExpressionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/NotExpressionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NotExpressionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="NotExpressionSerializer"/> class is to provide a <see cref="NotExpression"/> specific serializer
     /// </summary>
-    public class NotExpressionSerializer : IThingSerializer
+    public class NotExpressionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -62,8 +61,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), notExpression.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](notExpression.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](notExpression.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](notExpression.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](notExpression.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](notExpression.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](notExpression.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](notExpression.RevisionNumber));
@@ -88,7 +87,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var notExpression = thing as NotExpression;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/OptionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/OptionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OptionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="OptionSerializer"/> class is to provide a <see cref="Option"/> specific serializer
     /// </summary>
-    public class OptionSerializer : IThingSerializer
+    public class OptionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,17 +66,17 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Option option)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](option.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](option.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](option.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](option.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), option.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](option.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](option.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](option.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](option.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](option.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](option.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](option.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](option.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](option.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](option.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](option.Name));
-            jsonObject.Add("nestedElement", this.PropertySerializerMap["nestedElement"](option.NestedElement));
+            jsonObject.Add("nestedElement", this.PropertySerializerMap["nestedElement"](option.NestedElement.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](option.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](option.ShortName));
             return jsonObject;
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var option = thing as Option;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/OrExpressionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/OrExpressionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OrExpressionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="OrExpressionSerializer"/> class is to provide a <see cref="OrExpression"/> specific serializer
     /// </summary>
-    public class OrExpressionSerializer : IThingSerializer
+    public class OrExpressionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -62,12 +61,12 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), orExpression.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](orExpression.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](orExpression.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](orExpression.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](orExpression.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](orExpression.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](orExpression.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](orExpression.RevisionNumber));
-            jsonObject.Add("term", this.PropertySerializerMap["term"](orExpression.Term));
+            jsonObject.Add("term", this.PropertySerializerMap["term"](orExpression.Term.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -88,7 +87,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var orExpression = thing as OrExpression;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/OrdinalScaleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/OrdinalScaleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OrdinalScaleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="OrdinalScaleSerializer"/> class is to provide a <see cref="OrdinalScale"/> specific serializer
     /// </summary>
-    public class OrdinalScaleSerializer : IThingSerializer
+    public class OrdinalScaleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -77,17 +76,17 @@ namespace CDP4JsonSerializer
         private JObject Serialize(OrdinalScale ordinalScale)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](ordinalScale.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](ordinalScale.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), ordinalScale.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](ordinalScale.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](ordinalScale.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](ordinalScale.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](ordinalScale.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](ordinalScale.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](ordinalScale.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](ordinalScale.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](ordinalScale.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](ordinalScale.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](ordinalScale.IsDeprecated));
             jsonObject.Add("isMaximumInclusive", this.PropertySerializerMap["isMaximumInclusive"](ordinalScale.IsMaximumInclusive));
             jsonObject.Add("isMinimumInclusive", this.PropertySerializerMap["isMinimumInclusive"](ordinalScale.IsMinimumInclusive));
-            jsonObject.Add("mappingToReferenceScale", this.PropertySerializerMap["mappingToReferenceScale"](ordinalScale.MappingToReferenceScale));
+            jsonObject.Add("mappingToReferenceScale", this.PropertySerializerMap["mappingToReferenceScale"](ordinalScale.MappingToReferenceScale.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("maximumPermissibleValue", this.PropertySerializerMap["maximumPermissibleValue"](ordinalScale.MaximumPermissibleValue));
             jsonObject.Add("minimumPermissibleValue", this.PropertySerializerMap["minimumPermissibleValue"](ordinalScale.MinimumPermissibleValue));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](ordinalScale.ModifiedOn));
@@ -99,7 +98,7 @@ namespace CDP4JsonSerializer
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](ordinalScale.ShortName));
             jsonObject.Add("unit", this.PropertySerializerMap["unit"](ordinalScale.Unit));
             jsonObject.Add("useShortNameValues", this.PropertySerializerMap["useShortNameValues"](ordinalScale.UseShortNameValues));
-            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](ordinalScale.ValueDefinition));
+            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](ordinalScale.ValueDefinition.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -120,7 +119,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var ordinalScale = thing as OrdinalScale;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/OrganizationSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/OrganizationSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OrganizationSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="OrganizationSerializer"/> class is to provide a <see cref="Organization"/> specific serializer
     /// </summary>
-    public class OrganizationSerializer : IThingSerializer
+    public class OrganizationSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), organization.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](organization.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](organization.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](organization.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](organization.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](organization.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](organization.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](organization.ModifiedOn));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var organization = thing as Organization;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/OwnedStyleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/OwnedStyleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OwnedStyleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="OwnedStyleSerializer"/> class is to provide a <see cref="OwnedStyle"/> specific serializer
     /// </summary>
-    public class OwnedStyleSerializer : IThingSerializer
+    public class OwnedStyleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -75,8 +74,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), ownedStyle.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](ownedStyle.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](ownedStyle.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](ownedStyle.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](ownedStyle.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("fillColor", this.PropertySerializerMap["fillColor"](ownedStyle.FillColor));
             jsonObject.Add("fillOpacity", this.PropertySerializerMap["fillOpacity"](ownedStyle.FillOpacity));
             jsonObject.Add("fontBold", this.PropertySerializerMap["fontBold"](ownedStyle.FontBold));
@@ -93,7 +92,7 @@ namespace CDP4JsonSerializer
             jsonObject.Add("strokeColor", this.PropertySerializerMap["strokeColor"](ownedStyle.StrokeColor));
             jsonObject.Add("strokeOpacity", this.PropertySerializerMap["strokeOpacity"](ownedStyle.StrokeOpacity));
             jsonObject.Add("strokeWidth", this.PropertySerializerMap["strokeWidth"](ownedStyle.StrokeWidth));
-            jsonObject.Add("usedColor", this.PropertySerializerMap["usedColor"](ownedStyle.UsedColor));
+            jsonObject.Add("usedColor", this.PropertySerializerMap["usedColor"](ownedStyle.UsedColor.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -114,7 +113,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var ownedStyle = thing as OwnedStyle;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/PageSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/PageSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PageSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="PageSerializer"/> class is to provide a <see cref="Page"/> specific serializer
     /// </summary>
-    public class PageSerializer : IThingSerializer
+    public class PageSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,15 +65,15 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Page page)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("category", this.PropertySerializerMap["category"](page.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](page.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), page.ClassKind)));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](page.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](page.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](page.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](page.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](page.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](page.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](page.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](page.Name));
-            jsonObject.Add("note", this.PropertySerializerMap["note"](page.Note));
+            jsonObject.Add("note", this.PropertySerializerMap["note"](page.Note.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](page.Owner));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](page.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](page.ShortName));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var page = thing as Page;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterGroupSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterGroupSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterGroupSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParameterGroupSerializer"/> class is to provide a <see cref="ParameterGroup"/> specific serializer
     /// </summary>
-    public class ParameterGroupSerializer : IThingSerializer
+    public class ParameterGroupSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), parameterGroup.ClassKind)));
             jsonObject.Add("containingGroup", this.PropertySerializerMap["containingGroup"](parameterGroup.ContainingGroup));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterGroup.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterGroup.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterGroup.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterGroup.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](parameterGroup.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](parameterGroup.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](parameterGroup.Name));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var parameterGroup = thing as ParameterGroup;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterOverrideSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterOverrideSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterOverrideSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParameterOverrideSerializer"/> class is to provide a <see cref="ParameterOverride"/> specific serializer
     /// </summary>
-    public class ParameterOverrideSerializer : IThingSerializer
+    public class ParameterOverrideSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,15 +64,15 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), parameterOverride.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterOverride.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterOverride.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterOverride.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterOverride.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](parameterOverride.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](parameterOverride.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](parameterOverride.Owner));
             jsonObject.Add("parameter", this.PropertySerializerMap["parameter"](parameterOverride.Parameter));
-            jsonObject.Add("parameterSubscription", this.PropertySerializerMap["parameterSubscription"](parameterOverride.ParameterSubscription));
+            jsonObject.Add("parameterSubscription", this.PropertySerializerMap["parameterSubscription"](parameterOverride.ParameterSubscription.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](parameterOverride.RevisionNumber));
-            jsonObject.Add("valueSet", this.PropertySerializerMap["valueSet"](parameterOverride.ValueSet));
+            jsonObject.Add("valueSet", this.PropertySerializerMap["valueSet"](parameterOverride.ValueSet.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -94,7 +93,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var parameterOverride = thing as ParameterOverride;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterOverrideValueSetSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterOverrideValueSetSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterOverrideValueSetSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParameterOverrideValueSetSerializer"/> class is to provide a <see cref="ParameterOverrideValueSet"/> specific serializer
     /// </summary>
-    public class ParameterOverrideValueSetSerializer : IThingSerializer
+    public class ParameterOverrideValueSetSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -69,8 +68,8 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), parameterOverrideValueSet.ClassKind)));
             jsonObject.Add("computed", this.PropertySerializerMap["computed"](parameterOverrideValueSet.Computed));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterOverrideValueSet.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterOverrideValueSet.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterOverrideValueSet.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterOverrideValueSet.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("formula", this.PropertySerializerMap["formula"](parameterOverrideValueSet.Formula));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](parameterOverrideValueSet.Iid));
             jsonObject.Add("manual", this.PropertySerializerMap["manual"](parameterOverrideValueSet.Manual));
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var parameterOverrideValueSet = thing as ParameterOverrideValueSet;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParameterSerializer"/> class is to provide a <see cref="Parameter"/> specific serializer
     /// </summary>
-    public class ParameterSerializer : IThingSerializer
+    public class ParameterSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -73,21 +72,21 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("allowDifferentOwnerOfOverride", this.PropertySerializerMap["allowDifferentOwnerOfOverride"](parameter.AllowDifferentOwnerOfOverride));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), parameter.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameter.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameter.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameter.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameter.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("expectsOverride", this.PropertySerializerMap["expectsOverride"](parameter.ExpectsOverride));
             jsonObject.Add("group", this.PropertySerializerMap["group"](parameter.Group));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](parameter.Iid));
             jsonObject.Add("isOptionDependent", this.PropertySerializerMap["isOptionDependent"](parameter.IsOptionDependent));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](parameter.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](parameter.Owner));
-            jsonObject.Add("parameterSubscription", this.PropertySerializerMap["parameterSubscription"](parameter.ParameterSubscription));
+            jsonObject.Add("parameterSubscription", this.PropertySerializerMap["parameterSubscription"](parameter.ParameterSubscription.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](parameter.ParameterType));
             jsonObject.Add("requestedBy", this.PropertySerializerMap["requestedBy"](parameter.RequestedBy));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](parameter.RevisionNumber));
             jsonObject.Add("scale", this.PropertySerializerMap["scale"](parameter.Scale));
             jsonObject.Add("stateDependence", this.PropertySerializerMap["stateDependence"](parameter.StateDependence));
-            jsonObject.Add("valueSet", this.PropertySerializerMap["valueSet"](parameter.ValueSet));
+            jsonObject.Add("valueSet", this.PropertySerializerMap["valueSet"](parameter.ValueSet.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -108,7 +107,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var parameter = thing as Parameter;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterSubscriptionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterSubscriptionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterSubscriptionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParameterSubscriptionSerializer"/> class is to provide a <see cref="ParameterSubscription"/> specific serializer
     /// </summary>
-    public class ParameterSubscriptionSerializer : IThingSerializer
+    public class ParameterSubscriptionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,13 +62,13 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), parameterSubscription.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterSubscription.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterSubscription.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterSubscription.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterSubscription.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](parameterSubscription.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](parameterSubscription.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](parameterSubscription.Owner));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](parameterSubscription.RevisionNumber));
-            jsonObject.Add("valueSet", this.PropertySerializerMap["valueSet"](parameterSubscription.ValueSet));
+            jsonObject.Add("valueSet", this.PropertySerializerMap["valueSet"](parameterSubscription.ValueSet.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var parameterSubscription = thing as ParameterSubscription;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterSubscriptionValueSetSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterSubscriptionValueSetSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterSubscriptionValueSetSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParameterSubscriptionValueSetSerializer"/> class is to provide a <see cref="ParameterSubscriptionValueSet"/> specific serializer
     /// </summary>
-    public class ParameterSubscriptionValueSetSerializer : IThingSerializer
+    public class ParameterSubscriptionValueSetSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), parameterSubscriptionValueSet.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterSubscriptionValueSet.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterSubscriptionValueSet.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterSubscriptionValueSet.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterSubscriptionValueSet.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](parameterSubscriptionValueSet.Iid));
             jsonObject.Add("manual", this.PropertySerializerMap["manual"](parameterSubscriptionValueSet.Manual));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](parameterSubscriptionValueSet.ModifiedOn));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var parameterSubscriptionValueSet = thing as ParameterSubscriptionValueSet;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterTypeComponentSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterTypeComponentSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterTypeComponentSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParameterTypeComponentSerializer"/> class is to provide a <see cref="ParameterTypeComponent"/> specific serializer
     /// </summary>
-    public class ParameterTypeComponentSerializer : IThingSerializer
+    public class ParameterTypeComponentSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), parameterTypeComponent.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterTypeComponent.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterTypeComponent.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterTypeComponent.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterTypeComponent.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](parameterTypeComponent.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](parameterTypeComponent.ModifiedOn));
             jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](parameterTypeComponent.ParameterType));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var parameterTypeComponent = thing as ParameterTypeComponent;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterValueSetSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterValueSetSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterValueSetSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParameterValueSetSerializer"/> class is to provide a <see cref="ParameterValueSet"/> specific serializer
     /// </summary>
-    public class ParameterValueSetSerializer : IThingSerializer
+    public class ParameterValueSetSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -72,8 +71,8 @@ namespace CDP4JsonSerializer
             jsonObject.Add("actualState", this.PropertySerializerMap["actualState"](parameterValueSet.ActualState));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), parameterValueSet.ClassKind)));
             jsonObject.Add("computed", this.PropertySerializerMap["computed"](parameterValueSet.Computed));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterValueSet.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterValueSet.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterValueSet.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterValueSet.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("formula", this.PropertySerializerMap["formula"](parameterValueSet.Formula));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](parameterValueSet.Iid));
             jsonObject.Add("manual", this.PropertySerializerMap["manual"](parameterValueSet.Manual));
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var parameterValueSet = thing as ParameterValueSet;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterizedCategoryRuleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParameterizedCategoryRuleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterizedCategoryRuleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParameterizedCategoryRuleSerializer"/> class is to provide a <see cref="ParameterizedCategoryRule"/> specific serializer
     /// </summary>
-    public class ParameterizedCategoryRuleSerializer : IThingSerializer
+    public class ParameterizedCategoryRuleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,18 +67,18 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ParameterizedCategoryRule parameterizedCategoryRule)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](parameterizedCategoryRule.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](parameterizedCategoryRule.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("category", this.PropertySerializerMap["category"](parameterizedCategoryRule.Category));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), parameterizedCategoryRule.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](parameterizedCategoryRule.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterizedCategoryRule.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterizedCategoryRule.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](parameterizedCategoryRule.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](parameterizedCategoryRule.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parameterizedCategoryRule.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parameterizedCategoryRule.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](parameterizedCategoryRule.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](parameterizedCategoryRule.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](parameterizedCategoryRule.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](parameterizedCategoryRule.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](parameterizedCategoryRule.Name));
-            jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](parameterizedCategoryRule.ParameterType));
+            jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](parameterizedCategoryRule.ParameterType.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](parameterizedCategoryRule.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](parameterizedCategoryRule.ShortName));
             return jsonObject;
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var parameterizedCategoryRule = thing as ParameterizedCategoryRule;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParametricConstraintSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParametricConstraintSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParametricConstraintSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParametricConstraintSerializer"/> class is to provide a <see cref="ParametricConstraint"/> specific serializer
     /// </summary>
-    public class ParametricConstraintSerializer : IThingSerializer
+    public class ParametricConstraintSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,9 +62,9 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), parametricConstraint.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parametricConstraint.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parametricConstraint.ExcludedPerson));
-            jsonObject.Add("expression", this.PropertySerializerMap["expression"](parametricConstraint.Expression));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](parametricConstraint.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](parametricConstraint.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("expression", this.PropertySerializerMap["expression"](parametricConstraint.Expression.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](parametricConstraint.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](parametricConstraint.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](parametricConstraint.RevisionNumber));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var parametricConstraint = thing as ParametricConstraint;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParticipantPermissionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParticipantPermissionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParticipantPermissionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParticipantPermissionSerializer"/> class is to provide a <see cref="ParticipantPermission"/> specific serializer
     /// </summary>
-    public class ParticipantPermissionSerializer : IThingSerializer
+    public class ParticipantPermissionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,8 +64,8 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("accessRight", this.PropertySerializerMap["accessRight"](Enum.GetName(typeof(CDP4Common.CommonData.ParticipantAccessRightKind), participantPermission.AccessRight)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), participantPermission.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](participantPermission.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](participantPermission.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](participantPermission.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](participantPermission.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](participantPermission.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](participantPermission.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](participantPermission.ModifiedOn));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var participantPermission = thing as ParticipantPermission;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParticipantRoleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParticipantRoleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParticipantRoleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParticipantRoleSerializer"/> class is to provide a <see cref="ParticipantRole"/> specific serializer
     /// </summary>
-    public class ParticipantRoleSerializer : IThingSerializer
+    public class ParticipantRoleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,17 +66,17 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ParticipantRole participantRole)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](participantRole.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](participantRole.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), participantRole.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](participantRole.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](participantRole.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](participantRole.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](participantRole.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](participantRole.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](participantRole.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](participantRole.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](participantRole.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](participantRole.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](participantRole.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](participantRole.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](participantRole.Name));
-            jsonObject.Add("participantPermission", this.PropertySerializerMap["participantPermission"](participantRole.ParticipantPermission));
+            jsonObject.Add("participantPermission", this.PropertySerializerMap["participantPermission"](participantRole.ParticipantPermission.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](participantRole.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](participantRole.ShortName));
             return jsonObject;
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var participantRole = thing as ParticipantRole;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ParticipantSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ParticipantSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParticipantSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ParticipantSerializer"/> class is to provide a <see cref="Participant"/> specific serializer
     /// </summary>
-    public class ParticipantSerializer : IThingSerializer
+    public class ParticipantSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,9 +65,9 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), participant.ClassKind)));
-            jsonObject.Add("domain", this.PropertySerializerMap["domain"](participant.Domain));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](participant.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](participant.ExcludedPerson));
+            jsonObject.Add("domain", this.PropertySerializerMap["domain"](participant.Domain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](participant.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](participant.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](participant.Iid));
             jsonObject.Add("isActive", this.PropertySerializerMap["isActive"](participant.IsActive));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](participant.ModifiedOn));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var participant = thing as Participant;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/PersonPermissionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/PersonPermissionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PersonPermissionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="PersonPermissionSerializer"/> class is to provide a <see cref="PersonPermission"/> specific serializer
     /// </summary>
-    public class PersonPermissionSerializer : IThingSerializer
+    public class PersonPermissionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,8 +64,8 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("accessRight", this.PropertySerializerMap["accessRight"](Enum.GetName(typeof(CDP4Common.CommonData.PersonAccessRightKind), personPermission.AccessRight)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), personPermission.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](personPermission.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](personPermission.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](personPermission.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](personPermission.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](personPermission.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](personPermission.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](personPermission.ModifiedOn));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var personPermission = thing as PersonPermission;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/PersonRoleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/PersonRoleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PersonRoleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="PersonRoleSerializer"/> class is to provide a <see cref="PersonRole"/> specific serializer
     /// </summary>
-    public class PersonRoleSerializer : IThingSerializer
+    public class PersonRoleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,17 +66,17 @@ namespace CDP4JsonSerializer
         private JObject Serialize(PersonRole personRole)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](personRole.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](personRole.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), personRole.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](personRole.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](personRole.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](personRole.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](personRole.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](personRole.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](personRole.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](personRole.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](personRole.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](personRole.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](personRole.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](personRole.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](personRole.Name));
-            jsonObject.Add("personPermission", this.PropertySerializerMap["personPermission"](personRole.PersonPermission));
+            jsonObject.Add("personPermission", this.PropertySerializerMap["personPermission"](personRole.PersonPermission.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](personRole.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](personRole.ShortName));
             return jsonObject;
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var personRole = thing as PersonRole;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/PersonSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/PersonSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PersonSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="PersonSerializer"/> class is to provide a <see cref="Person"/> specific serializer
     /// </summary>
-    public class PersonSerializer : IThingSerializer
+    public class PersonSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -79,9 +78,9 @@ namespace CDP4JsonSerializer
             jsonObject.Add("defaultDomain", this.PropertySerializerMap["defaultDomain"](person.DefaultDomain));
             jsonObject.Add("defaultEmailAddress", this.PropertySerializerMap["defaultEmailAddress"](person.DefaultEmailAddress));
             jsonObject.Add("defaultTelephoneNumber", this.PropertySerializerMap["defaultTelephoneNumber"](person.DefaultTelephoneNumber));
-            jsonObject.Add("emailAddress", this.PropertySerializerMap["emailAddress"](person.EmailAddress));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](person.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](person.ExcludedPerson));
+            jsonObject.Add("emailAddress", this.PropertySerializerMap["emailAddress"](person.EmailAddress.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](person.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](person.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("givenName", this.PropertySerializerMap["givenName"](person.GivenName));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](person.Iid));
             jsonObject.Add("isActive", this.PropertySerializerMap["isActive"](person.IsActive));
@@ -94,8 +93,8 @@ namespace CDP4JsonSerializer
             jsonObject.Add("role", this.PropertySerializerMap["role"](person.Role));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](person.ShortName));
             jsonObject.Add("surname", this.PropertySerializerMap["surname"](person.Surname));
-            jsonObject.Add("telephoneNumber", this.PropertySerializerMap["telephoneNumber"](person.TelephoneNumber));
-            jsonObject.Add("userPreference", this.PropertySerializerMap["userPreference"](person.UserPreference));
+            jsonObject.Add("telephoneNumber", this.PropertySerializerMap["telephoneNumber"](person.TelephoneNumber.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("userPreference", this.PropertySerializerMap["userPreference"](person.UserPreference.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -116,7 +115,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var person = thing as Person;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/PointSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/PointSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PointSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="PointSerializer"/> class is to provide a <see cref="Point"/> specific serializer
     /// </summary>
-    public class PointSerializer : IThingSerializer
+    public class PointSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), point.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](point.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](point.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](point.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](point.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](point.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](point.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](point.Name));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var point = thing as Point;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/PossibleFiniteStateListSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/PossibleFiniteStateListSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PossibleFiniteStateListSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="PossibleFiniteStateListSerializer"/> class is to provide a <see cref="PossibleFiniteStateList"/> specific serializer
     /// </summary>
-    public class PossibleFiniteStateListSerializer : IThingSerializer
+    public class PossibleFiniteStateListSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -69,19 +68,19 @@ namespace CDP4JsonSerializer
         private JObject Serialize(PossibleFiniteStateList possibleFiniteStateList)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](possibleFiniteStateList.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](possibleFiniteStateList.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](possibleFiniteStateList.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](possibleFiniteStateList.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), possibleFiniteStateList.ClassKind)));
             jsonObject.Add("defaultState", this.PropertySerializerMap["defaultState"](possibleFiniteStateList.DefaultState));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](possibleFiniteStateList.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](possibleFiniteStateList.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](possibleFiniteStateList.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](possibleFiniteStateList.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](possibleFiniteStateList.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](possibleFiniteStateList.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](possibleFiniteStateList.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](possibleFiniteStateList.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](possibleFiniteStateList.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](possibleFiniteStateList.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](possibleFiniteStateList.Name));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](possibleFiniteStateList.Owner));
-            jsonObject.Add("possibleState", this.PropertySerializerMap["possibleState"](possibleFiniteStateList.PossibleState));
+            jsonObject.Add("possibleState", this.PropertySerializerMap["possibleState"](possibleFiniteStateList.PossibleState.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](possibleFiniteStateList.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](possibleFiniteStateList.ShortName));
             return jsonObject;
@@ -104,7 +103,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var possibleFiniteStateList = thing as PossibleFiniteStateList;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/PossibleFiniteStateSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/PossibleFiniteStateSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PossibleFiniteStateSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="PossibleFiniteStateSerializer"/> class is to provide a <see cref="PossibleFiniteState"/> specific serializer
     /// </summary>
-    public class PossibleFiniteStateSerializer : IThingSerializer
+    public class PossibleFiniteStateSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,12 +64,12 @@ namespace CDP4JsonSerializer
         private JObject Serialize(PossibleFiniteState possibleFiniteState)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](possibleFiniteState.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](possibleFiniteState.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), possibleFiniteState.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](possibleFiniteState.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](possibleFiniteState.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](possibleFiniteState.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](possibleFiniteState.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](possibleFiniteState.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](possibleFiniteState.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](possibleFiniteState.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](possibleFiniteState.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](possibleFiniteState.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](possibleFiniteState.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](possibleFiniteState.Name));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var possibleFiniteState = thing as PossibleFiniteState;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/PrefixedUnitSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/PrefixedUnitSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PrefixedUnitSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="PrefixedUnitSerializer"/> class is to provide a <see cref="PrefixedUnit"/> specific serializer
     /// </summary>
-    public class PrefixedUnitSerializer : IThingSerializer
+    public class PrefixedUnitSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,12 +65,12 @@ namespace CDP4JsonSerializer
         private JObject Serialize(PrefixedUnit prefixedUnit)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](prefixedUnit.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](prefixedUnit.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), prefixedUnit.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](prefixedUnit.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](prefixedUnit.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](prefixedUnit.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](prefixedUnit.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](prefixedUnit.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](prefixedUnit.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](prefixedUnit.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](prefixedUnit.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](prefixedUnit.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](prefixedUnit.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](prefixedUnit.ModifiedOn));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var prefixedUnit = thing as PrefixedUnit;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/PublicationSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/PublicationSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PublicationSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="PublicationSerializer"/> class is to provide a <see cref="Publication"/> specific serializer
     /// </summary>
-    public class PublicationSerializer : IThingSerializer
+    public class PublicationSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,12 +64,12 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), publication.ClassKind)));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](publication.CreatedOn));
-            jsonObject.Add("domain", this.PropertySerializerMap["domain"](publication.Domain));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](publication.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](publication.ExcludedPerson));
+            jsonObject.Add("domain", this.PropertySerializerMap["domain"](publication.Domain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](publication.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](publication.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](publication.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](publication.ModifiedOn));
-            jsonObject.Add("publishedParameter", this.PropertySerializerMap["publishedParameter"](publication.PublishedParameter));
+            jsonObject.Add("publishedParameter", this.PropertySerializerMap["publishedParameter"](publication.PublishedParameter.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](publication.RevisionNumber));
             return jsonObject;
         }
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var publication = thing as Publication;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/QuantityKindFactorSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/QuantityKindFactorSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="QuantityKindFactorSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="QuantityKindFactorSerializer"/> class is to provide a <see cref="QuantityKindFactor"/> specific serializer
     /// </summary>
-    public class QuantityKindFactorSerializer : IThingSerializer
+    public class QuantityKindFactorSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,8 +62,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), quantityKindFactor.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](quantityKindFactor.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](quantityKindFactor.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](quantityKindFactor.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](quantityKindFactor.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("exponent", this.PropertySerializerMap["exponent"](quantityKindFactor.Exponent));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](quantityKindFactor.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](quantityKindFactor.ModifiedOn));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var quantityKindFactor = thing as QuantityKindFactor;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RatioScaleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RatioScaleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RatioScaleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RatioScaleSerializer"/> class is to provide a <see cref="RatioScale"/> specific serializer
     /// </summary>
-    public class RatioScaleSerializer : IThingSerializer
+    public class RatioScaleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -76,17 +75,17 @@ namespace CDP4JsonSerializer
         private JObject Serialize(RatioScale ratioScale)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](ratioScale.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](ratioScale.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), ratioScale.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](ratioScale.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](ratioScale.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](ratioScale.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](ratioScale.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](ratioScale.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](ratioScale.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](ratioScale.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](ratioScale.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](ratioScale.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](ratioScale.IsDeprecated));
             jsonObject.Add("isMaximumInclusive", this.PropertySerializerMap["isMaximumInclusive"](ratioScale.IsMaximumInclusive));
             jsonObject.Add("isMinimumInclusive", this.PropertySerializerMap["isMinimumInclusive"](ratioScale.IsMinimumInclusive));
-            jsonObject.Add("mappingToReferenceScale", this.PropertySerializerMap["mappingToReferenceScale"](ratioScale.MappingToReferenceScale));
+            jsonObject.Add("mappingToReferenceScale", this.PropertySerializerMap["mappingToReferenceScale"](ratioScale.MappingToReferenceScale.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("maximumPermissibleValue", this.PropertySerializerMap["maximumPermissibleValue"](ratioScale.MaximumPermissibleValue));
             jsonObject.Add("minimumPermissibleValue", this.PropertySerializerMap["minimumPermissibleValue"](ratioScale.MinimumPermissibleValue));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](ratioScale.ModifiedOn));
@@ -97,7 +96,7 @@ namespace CDP4JsonSerializer
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](ratioScale.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](ratioScale.ShortName));
             jsonObject.Add("unit", this.PropertySerializerMap["unit"](ratioScale.Unit));
-            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](ratioScale.ValueDefinition));
+            jsonObject.Add("valueDefinition", this.PropertySerializerMap["valueDefinition"](ratioScale.ValueDefinition.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -118,7 +117,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var ratioScale = thing as RatioScale;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ReferenceSourceSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ReferenceSourceSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ReferenceSourceSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ReferenceSourceSerializer"/> class is to provide a <see cref="ReferenceSource"/> specific serializer
     /// </summary>
-    public class ReferenceSourceSerializer : IThingSerializer
+    public class ReferenceSourceSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -74,14 +73,14 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ReferenceSource referenceSource)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](referenceSource.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](referenceSource.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("author", this.PropertySerializerMap["author"](referenceSource.Author));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](referenceSource.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](referenceSource.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), referenceSource.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](referenceSource.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](referenceSource.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](referenceSource.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](referenceSource.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](referenceSource.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](referenceSource.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](referenceSource.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](referenceSource.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](referenceSource.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](referenceSource.IsDeprecated));
             jsonObject.Add("language", this.PropertySerializerMap["language"](referenceSource.Language));
@@ -114,7 +113,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var referenceSource = thing as ReferenceSource;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ReferencerRuleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ReferencerRuleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ReferencerRuleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ReferencerRuleSerializer"/> class is to provide a <see cref="ReferencerRule"/> specific serializer
     /// </summary>
-    public class ReferencerRuleSerializer : IThingSerializer
+    public class ReferencerRuleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -70,19 +69,19 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ReferencerRule referencerRule)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](referencerRule.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](referencerRule.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), referencerRule.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](referencerRule.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](referencerRule.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](referencerRule.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](referencerRule.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](referencerRule.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](referencerRule.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](referencerRule.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](referencerRule.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](referencerRule.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](referencerRule.IsDeprecated));
             jsonObject.Add("maxReferenced", this.PropertySerializerMap["maxReferenced"](referencerRule.MaxReferenced));
             jsonObject.Add("minReferenced", this.PropertySerializerMap["minReferenced"](referencerRule.MinReferenced));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](referencerRule.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](referencerRule.Name));
-            jsonObject.Add("referencedCategory", this.PropertySerializerMap["referencedCategory"](referencerRule.ReferencedCategory));
+            jsonObject.Add("referencedCategory", this.PropertySerializerMap["referencedCategory"](referencerRule.ReferencedCategory.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("referencingCategory", this.PropertySerializerMap["referencingCategory"](referencerRule.ReferencingCategory));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](referencerRule.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](referencerRule.ShortName));
@@ -106,7 +105,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var referencerRule = thing as ReferencerRule;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RelationalExpressionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RelationalExpressionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationalExpressionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RelationalExpressionSerializer"/> class is to provide a <see cref="RelationalExpression"/> specific serializer
     /// </summary>
-    public class RelationalExpressionSerializer : IThingSerializer
+    public class RelationalExpressionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,8 +64,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), relationalExpression.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](relationalExpression.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](relationalExpression.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](relationalExpression.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](relationalExpression.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](relationalExpression.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](relationalExpression.ModifiedOn));
             jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](relationalExpression.ParameterType));
@@ -94,7 +93,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var relationalExpression = thing as RelationalExpression;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RelationshipParameterValueSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RelationshipParameterValueSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationshipParameterValueSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RelationshipParameterValueSerializer"/> class is to provide a <see cref="RelationshipParameterValue"/> specific serializer
     /// </summary>
-    public class RelationshipParameterValueSerializer : IThingSerializer
+    public class RelationshipParameterValueSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), relationshipParameterValue.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](relationshipParameterValue.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](relationshipParameterValue.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](relationshipParameterValue.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](relationshipParameterValue.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](relationshipParameterValue.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](relationshipParameterValue.ModifiedOn));
             jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](relationshipParameterValue.ParameterType));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var relationshipParameterValue = thing as RelationshipParameterValue;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RequestForDeviationSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RequestForDeviationSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequestForDeviationSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RequestForDeviationSerializer"/> class is to provide a <see cref="RequestForDeviation"/> specific serializer
     /// </summary>
-    public class RequestForDeviationSerializer : IThingSerializer
+    public class RequestForDeviationSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -75,25 +74,25 @@ namespace CDP4JsonSerializer
         private JObject Serialize(RequestForDeviation requestForDeviation)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](requestForDeviation.ApprovedBy));
+            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](requestForDeviation.ApprovedBy.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("author", this.PropertySerializerMap["author"](requestForDeviation.Author));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](requestForDeviation.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](requestForDeviation.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classification", this.PropertySerializerMap["classification"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationClassificationKind), requestForDeviation.Classification)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), requestForDeviation.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](requestForDeviation.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](requestForDeviation.CreatedOn));
-            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](requestForDeviation.Discussion));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requestForDeviation.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requestForDeviation.ExcludedPerson));
+            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](requestForDeviation.Discussion.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requestForDeviation.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requestForDeviation.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](requestForDeviation.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](requestForDeviation.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](requestForDeviation.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](requestForDeviation.Owner));
             jsonObject.Add("primaryAnnotatedThing", this.PropertySerializerMap["primaryAnnotatedThing"](requestForDeviation.PrimaryAnnotatedThing));
-            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](requestForDeviation.RelatedThing));
+            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](requestForDeviation.RelatedThing.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](requestForDeviation.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](requestForDeviation.ShortName));
-            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](requestForDeviation.SourceAnnotation));
+            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](requestForDeviation.SourceAnnotation.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("status", this.PropertySerializerMap["status"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationStatusKind), requestForDeviation.Status)));
             jsonObject.Add("title", this.PropertySerializerMap["title"](requestForDeviation.Title));
             return jsonObject;
@@ -116,7 +115,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var requestForDeviation = thing as RequestForDeviation;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RequestForWaiverSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RequestForWaiverSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequestForWaiverSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RequestForWaiverSerializer"/> class is to provide a <see cref="RequestForWaiver"/> specific serializer
     /// </summary>
-    public class RequestForWaiverSerializer : IThingSerializer
+    public class RequestForWaiverSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -75,25 +74,25 @@ namespace CDP4JsonSerializer
         private JObject Serialize(RequestForWaiver requestForWaiver)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](requestForWaiver.ApprovedBy));
+            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](requestForWaiver.ApprovedBy.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("author", this.PropertySerializerMap["author"](requestForWaiver.Author));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](requestForWaiver.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](requestForWaiver.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classification", this.PropertySerializerMap["classification"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationClassificationKind), requestForWaiver.Classification)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), requestForWaiver.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](requestForWaiver.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](requestForWaiver.CreatedOn));
-            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](requestForWaiver.Discussion));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requestForWaiver.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requestForWaiver.ExcludedPerson));
+            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](requestForWaiver.Discussion.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requestForWaiver.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requestForWaiver.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](requestForWaiver.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](requestForWaiver.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](requestForWaiver.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](requestForWaiver.Owner));
             jsonObject.Add("primaryAnnotatedThing", this.PropertySerializerMap["primaryAnnotatedThing"](requestForWaiver.PrimaryAnnotatedThing));
-            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](requestForWaiver.RelatedThing));
+            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](requestForWaiver.RelatedThing.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](requestForWaiver.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](requestForWaiver.ShortName));
-            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](requestForWaiver.SourceAnnotation));
+            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](requestForWaiver.SourceAnnotation.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("status", this.PropertySerializerMap["status"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationStatusKind), requestForWaiver.Status)));
             jsonObject.Add("title", this.PropertySerializerMap["title"](requestForWaiver.Title));
             return jsonObject;
@@ -116,7 +115,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var requestForWaiver = thing as RequestForWaiver;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RequirementSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RequirementSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequirementSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RequirementSerializer"/> class is to provide a <see cref="Requirement"/> specific serializer
     /// </summary>
-    public class RequirementSerializer : IThingSerializer
+    public class RequirementSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,21 +70,21 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Requirement requirement)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](requirement.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](requirement.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](requirement.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](requirement.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), requirement.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](requirement.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requirement.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requirement.ExcludedPerson));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](requirement.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requirement.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requirement.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("group", this.PropertySerializerMap["group"](requirement.Group));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](requirement.HyperLink));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](requirement.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](requirement.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](requirement.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](requirement.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](requirement.Name));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](requirement.Owner));
-            jsonObject.Add("parameterValue", this.PropertySerializerMap["parameterValue"](requirement.ParameterValue));
-            jsonObject.Add("parametricConstraint", this.PropertySerializerMap["parametricConstraint"](requirement.ParametricConstraint));
+            jsonObject.Add("parameterValue", this.PropertySerializerMap["parameterValue"](requirement.ParameterValue.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("parametricConstraint", this.PropertySerializerMap["parametricConstraint"](requirement.ParametricConstraint.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](requirement.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](requirement.ShortName));
             return jsonObject;
@@ -108,7 +107,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var requirement = thing as Requirement;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RequirementsContainerParameterValueSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RequirementsContainerParameterValueSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequirementsContainerParameterValueSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RequirementsContainerParameterValueSerializer"/> class is to provide a <see cref="RequirementsContainerParameterValue"/> specific serializer
     /// </summary>
-    public class RequirementsContainerParameterValueSerializer : IThingSerializer
+    public class RequirementsContainerParameterValueSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), requirementsContainerParameterValue.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requirementsContainerParameterValue.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requirementsContainerParameterValue.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requirementsContainerParameterValue.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requirementsContainerParameterValue.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](requirementsContainerParameterValue.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](requirementsContainerParameterValue.ModifiedOn));
             jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](requirementsContainerParameterValue.ParameterType));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var requirementsContainerParameterValue = thing as RequirementsContainerParameterValue;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RequirementsGroupSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RequirementsGroupSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequirementsGroupSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RequirementsGroupSerializer"/> class is to provide a <see cref="RequirementsGroup"/> specific serializer
     /// </summary>
-    public class RequirementsGroupSerializer : IThingSerializer
+    public class RequirementsGroupSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -69,19 +68,19 @@ namespace CDP4JsonSerializer
         private JObject Serialize(RequirementsGroup requirementsGroup)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](requirementsGroup.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](requirementsGroup.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](requirementsGroup.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](requirementsGroup.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), requirementsGroup.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](requirementsGroup.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requirementsGroup.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requirementsGroup.ExcludedPerson));
-            jsonObject.Add("group", this.PropertySerializerMap["group"](requirementsGroup.Group));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](requirementsGroup.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](requirementsGroup.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requirementsGroup.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requirementsGroup.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("group", this.PropertySerializerMap["group"](requirementsGroup.Group.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](requirementsGroup.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](requirementsGroup.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](requirementsGroup.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](requirementsGroup.Name));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](requirementsGroup.Owner));
-            jsonObject.Add("parameterValue", this.PropertySerializerMap["parameterValue"](requirementsGroup.ParameterValue));
+            jsonObject.Add("parameterValue", this.PropertySerializerMap["parameterValue"](requirementsGroup.ParameterValue.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](requirementsGroup.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](requirementsGroup.ShortName));
             return jsonObject;
@@ -104,7 +103,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var requirementsGroup = thing as RequirementsGroup;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RequirementsSpecificationSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RequirementsSpecificationSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequirementsSpecificationSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RequirementsSpecificationSerializer"/> class is to provide a <see cref="RequirementsSpecification"/> specific serializer
     /// </summary>
-    public class RequirementsSpecificationSerializer : IThingSerializer
+    public class RequirementsSpecificationSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,21 +70,21 @@ namespace CDP4JsonSerializer
         private JObject Serialize(RequirementsSpecification requirementsSpecification)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](requirementsSpecification.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](requirementsSpecification.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](requirementsSpecification.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](requirementsSpecification.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), requirementsSpecification.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](requirementsSpecification.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requirementsSpecification.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requirementsSpecification.ExcludedPerson));
-            jsonObject.Add("group", this.PropertySerializerMap["group"](requirementsSpecification.Group));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](requirementsSpecification.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](requirementsSpecification.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](requirementsSpecification.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](requirementsSpecification.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("group", this.PropertySerializerMap["group"](requirementsSpecification.Group.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](requirementsSpecification.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](requirementsSpecification.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](requirementsSpecification.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](requirementsSpecification.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](requirementsSpecification.Name));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](requirementsSpecification.Owner));
-            jsonObject.Add("parameterValue", this.PropertySerializerMap["parameterValue"](requirementsSpecification.ParameterValue));
-            jsonObject.Add("requirement", this.PropertySerializerMap["requirement"](requirementsSpecification.Requirement));
+            jsonObject.Add("parameterValue", this.PropertySerializerMap["parameterValue"](requirementsSpecification.ParameterValue.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("requirement", this.PropertySerializerMap["requirement"](requirementsSpecification.Requirement.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](requirementsSpecification.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](requirementsSpecification.ShortName));
             return jsonObject;
@@ -108,7 +107,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var requirementsSpecification = thing as RequirementsSpecification;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ReviewItemDiscrepancySerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ReviewItemDiscrepancySerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ReviewItemDiscrepancySerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ReviewItemDiscrepancySerializer"/> class is to provide a <see cref="ReviewItemDiscrepancy"/> specific serializer
     /// </summary>
-    public class ReviewItemDiscrepancySerializer : IThingSerializer
+    public class ReviewItemDiscrepancySerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -76,26 +75,26 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ReviewItemDiscrepancy reviewItemDiscrepancy)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](reviewItemDiscrepancy.ApprovedBy));
+            jsonObject.Add("approvedBy", this.PropertySerializerMap["approvedBy"](reviewItemDiscrepancy.ApprovedBy.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("author", this.PropertySerializerMap["author"](reviewItemDiscrepancy.Author));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](reviewItemDiscrepancy.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](reviewItemDiscrepancy.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classification", this.PropertySerializerMap["classification"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationClassificationKind), reviewItemDiscrepancy.Classification)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), reviewItemDiscrepancy.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](reviewItemDiscrepancy.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](reviewItemDiscrepancy.CreatedOn));
-            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](reviewItemDiscrepancy.Discussion));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](reviewItemDiscrepancy.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](reviewItemDiscrepancy.ExcludedPerson));
+            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](reviewItemDiscrepancy.Discussion.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](reviewItemDiscrepancy.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](reviewItemDiscrepancy.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](reviewItemDiscrepancy.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](reviewItemDiscrepancy.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](reviewItemDiscrepancy.ModifiedOn));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](reviewItemDiscrepancy.Owner));
             jsonObject.Add("primaryAnnotatedThing", this.PropertySerializerMap["primaryAnnotatedThing"](reviewItemDiscrepancy.PrimaryAnnotatedThing));
-            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](reviewItemDiscrepancy.RelatedThing));
+            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](reviewItemDiscrepancy.RelatedThing.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](reviewItemDiscrepancy.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](reviewItemDiscrepancy.ShortName));
-            jsonObject.Add("solution", this.PropertySerializerMap["solution"](reviewItemDiscrepancy.Solution));
-            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](reviewItemDiscrepancy.SourceAnnotation));
+            jsonObject.Add("solution", this.PropertySerializerMap["solution"](reviewItemDiscrepancy.Solution.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("sourceAnnotation", this.PropertySerializerMap["sourceAnnotation"](reviewItemDiscrepancy.SourceAnnotation.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("status", this.PropertySerializerMap["status"](Enum.GetName(typeof(CDP4Common.ReportingData.AnnotationStatusKind), reviewItemDiscrepancy.Status)));
             jsonObject.Add("title", this.PropertySerializerMap["title"](reviewItemDiscrepancy.Title));
             return jsonObject;
@@ -118,7 +117,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var reviewItemDiscrepancy = thing as ReviewItemDiscrepancy;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RuleVerificationListSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RuleVerificationListSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RuleVerificationListSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RuleVerificationListSerializer"/> class is to provide a <see cref="RuleVerificationList"/> specific serializer
     /// </summary>
-    public class RuleVerificationListSerializer : IThingSerializer
+    public class RuleVerificationListSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,18 +66,18 @@ namespace CDP4JsonSerializer
         private JObject Serialize(RuleVerificationList ruleVerificationList)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](ruleVerificationList.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](ruleVerificationList.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), ruleVerificationList.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](ruleVerificationList.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](ruleVerificationList.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](ruleVerificationList.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](ruleVerificationList.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](ruleVerificationList.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](ruleVerificationList.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](ruleVerificationList.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](ruleVerificationList.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](ruleVerificationList.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](ruleVerificationList.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](ruleVerificationList.Name));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](ruleVerificationList.Owner));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](ruleVerificationList.RevisionNumber));
-            jsonObject.Add("ruleVerification", this.PropertySerializerMap["ruleVerification"](ruleVerificationList.RuleVerification));
+            jsonObject.Add("ruleVerification", this.PropertySerializerMap["ruleVerification"](ruleVerificationList.RuleVerification.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](ruleVerificationList.ShortName));
             return jsonObject;
         }
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var ruleVerificationList = thing as RuleVerificationList;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/RuleViolationSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/RuleViolationSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RuleViolationSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="RuleViolationSerializer"/> class is to provide a <see cref="RuleViolation"/> specific serializer
     /// </summary>
-    public class RuleViolationSerializer : IThingSerializer
+    public class RuleViolationSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,12 +63,12 @@ namespace CDP4JsonSerializer
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), ruleViolation.ClassKind)));
             jsonObject.Add("description", this.PropertySerializerMap["description"](ruleViolation.Description));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](ruleViolation.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](ruleViolation.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](ruleViolation.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](ruleViolation.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](ruleViolation.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](ruleViolation.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](ruleViolation.RevisionNumber));
-            jsonObject.Add("violatingThing", this.PropertySerializerMap["violatingThing"](ruleViolation.ViolatingThing));
+            jsonObject.Add("violatingThing", this.PropertySerializerMap["violatingThing"](ruleViolation.ViolatingThing.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var ruleViolation = thing as RuleViolation;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ScaleReferenceQuantityValueSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ScaleReferenceQuantityValueSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ScaleReferenceQuantityValueSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ScaleReferenceQuantityValueSerializer"/> class is to provide a <see cref="ScaleReferenceQuantityValue"/> specific serializer
     /// </summary>
-    public class ScaleReferenceQuantityValueSerializer : IThingSerializer
+    public class ScaleReferenceQuantityValueSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,8 +62,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), scaleReferenceQuantityValue.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](scaleReferenceQuantityValue.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](scaleReferenceQuantityValue.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](scaleReferenceQuantityValue.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](scaleReferenceQuantityValue.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](scaleReferenceQuantityValue.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](scaleReferenceQuantityValue.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](scaleReferenceQuantityValue.RevisionNumber));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var scaleReferenceQuantityValue = thing as ScaleReferenceQuantityValue;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ScaleValueDefinitionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ScaleValueDefinitionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ScaleValueDefinitionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ScaleValueDefinitionSerializer"/> class is to provide a <see cref="ScaleValueDefinition"/> specific serializer
     /// </summary>
-    public class ScaleValueDefinitionSerializer : IThingSerializer
+    public class ScaleValueDefinitionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,12 +65,12 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ScaleValueDefinition scaleValueDefinition)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](scaleValueDefinition.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](scaleValueDefinition.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), scaleValueDefinition.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](scaleValueDefinition.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](scaleValueDefinition.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](scaleValueDefinition.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](scaleValueDefinition.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](scaleValueDefinition.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](scaleValueDefinition.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](scaleValueDefinition.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](scaleValueDefinition.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](scaleValueDefinition.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](scaleValueDefinition.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](scaleValueDefinition.Name));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var scaleValueDefinition = thing as ScaleValueDefinition;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SectionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SectionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SectionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SectionSerializer"/> class is to provide a <see cref="Section"/> specific serializer
     /// </summary>
-    public class SectionSerializer : IThingSerializer
+    public class SectionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,16 +65,16 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Section section)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("category", this.PropertySerializerMap["category"](section.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](section.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), section.ClassKind)));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](section.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](section.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](section.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](section.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](section.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](section.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](section.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](section.Name));
             jsonObject.Add("owner", this.PropertySerializerMap["owner"](section.Owner));
-            jsonObject.Add("page", this.PropertySerializerMap["page"](section.Page));
+            jsonObject.Add("page", this.PropertySerializerMap["page"](section.Page.OrderBy(x => x, this.orderedItemComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](section.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](section.ShortName));
             return jsonObject;
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var section = thing as Section;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SerializerProvider.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SerializerProvider.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SerializerProvider.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SharedStyleSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SharedStyleSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SharedStyleSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SharedStyleSerializer"/> class is to provide a <see cref="SharedStyle"/> specific serializer
     /// </summary>
-    public class SharedStyleSerializer : IThingSerializer
+    public class SharedStyleSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -75,8 +74,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), sharedStyle.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](sharedStyle.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](sharedStyle.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](sharedStyle.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](sharedStyle.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("fillColor", this.PropertySerializerMap["fillColor"](sharedStyle.FillColor));
             jsonObject.Add("fillOpacity", this.PropertySerializerMap["fillOpacity"](sharedStyle.FillOpacity));
             jsonObject.Add("fontBold", this.PropertySerializerMap["fontBold"](sharedStyle.FontBold));
@@ -93,7 +92,7 @@ namespace CDP4JsonSerializer
             jsonObject.Add("strokeColor", this.PropertySerializerMap["strokeColor"](sharedStyle.StrokeColor));
             jsonObject.Add("strokeOpacity", this.PropertySerializerMap["strokeOpacity"](sharedStyle.StrokeOpacity));
             jsonObject.Add("strokeWidth", this.PropertySerializerMap["strokeWidth"](sharedStyle.StrokeWidth));
-            jsonObject.Add("usedColor", this.PropertySerializerMap["usedColor"](sharedStyle.UsedColor));
+            jsonObject.Add("usedColor", this.PropertySerializerMap["usedColor"](sharedStyle.UsedColor.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -114,7 +113,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var sharedStyle = thing as SharedStyle;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SimpleParameterValueSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SimpleParameterValueSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SimpleParameterValueSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SimpleParameterValueSerializer"/> class is to provide a <see cref="SimpleParameterValue"/> specific serializer
     /// </summary>
-    public class SimpleParameterValueSerializer : IThingSerializer
+    public class SimpleParameterValueSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), simpleParameterValue.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](simpleParameterValue.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](simpleParameterValue.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](simpleParameterValue.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](simpleParameterValue.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](simpleParameterValue.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](simpleParameterValue.ModifiedOn));
             jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](simpleParameterValue.ParameterType));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var simpleParameterValue = thing as SimpleParameterValue;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SimpleQuantityKindSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SimpleQuantityKindSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SimpleQuantityKindSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SimpleQuantityKindSerializer"/> class is to provide a <see cref="SimpleQuantityKind"/> specific serializer
     /// </summary>
-    public class SimpleQuantityKindSerializer : IThingSerializer
+    public class SimpleQuantityKindSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,19 +70,19 @@ namespace CDP4JsonSerializer
         private JObject Serialize(SimpleQuantityKind simpleQuantityKind)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](simpleQuantityKind.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](simpleQuantityKind.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](simpleQuantityKind.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](simpleQuantityKind.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), simpleQuantityKind.ClassKind)));
             jsonObject.Add("defaultScale", this.PropertySerializerMap["defaultScale"](simpleQuantityKind.DefaultScale));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](simpleQuantityKind.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](simpleQuantityKind.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](simpleQuantityKind.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](simpleQuantityKind.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](simpleQuantityKind.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](simpleQuantityKind.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](simpleQuantityKind.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](simpleQuantityKind.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](simpleQuantityKind.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](simpleQuantityKind.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](simpleQuantityKind.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](simpleQuantityKind.Name));
-            jsonObject.Add("possibleScale", this.PropertySerializerMap["possibleScale"](simpleQuantityKind.PossibleScale));
+            jsonObject.Add("possibleScale", this.PropertySerializerMap["possibleScale"](simpleQuantityKind.PossibleScale.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("quantityDimensionSymbol", this.PropertySerializerMap["quantityDimensionSymbol"](simpleQuantityKind.QuantityDimensionSymbol));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](simpleQuantityKind.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](simpleQuantityKind.ShortName));
@@ -108,7 +107,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var simpleQuantityKind = thing as SimpleQuantityKind;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SimpleUnitSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SimpleUnitSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SimpleUnitSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SimpleUnitSerializer"/> class is to provide a <see cref="SimpleUnit"/> specific serializer
     /// </summary>
-    public class SimpleUnitSerializer : IThingSerializer
+    public class SimpleUnitSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,12 +65,12 @@ namespace CDP4JsonSerializer
         private JObject Serialize(SimpleUnit simpleUnit)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](simpleUnit.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](simpleUnit.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), simpleUnit.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](simpleUnit.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](simpleUnit.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](simpleUnit.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](simpleUnit.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](simpleUnit.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](simpleUnit.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](simpleUnit.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](simpleUnit.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](simpleUnit.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](simpleUnit.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](simpleUnit.ModifiedOn));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var simpleUnit = thing as SimpleUnit;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SiteDirectoryDataAnnotationSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SiteDirectoryDataAnnotationSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteDirectoryDataAnnotationSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SiteDirectoryDataAnnotationSerializer"/> class is to provide a <see cref="SiteDirectoryDataAnnotation"/> specific serializer
     /// </summary>
-    public class SiteDirectoryDataAnnotationSerializer : IThingSerializer
+    public class SiteDirectoryDataAnnotationSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,14 +70,14 @@ namespace CDP4JsonSerializer
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), siteDirectoryDataAnnotation.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](siteDirectoryDataAnnotation.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](siteDirectoryDataAnnotation.CreatedOn));
-            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](siteDirectoryDataAnnotation.Discussion));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteDirectoryDataAnnotation.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteDirectoryDataAnnotation.ExcludedPerson));
+            jsonObject.Add("discussion", this.PropertySerializerMap["discussion"](siteDirectoryDataAnnotation.Discussion.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteDirectoryDataAnnotation.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteDirectoryDataAnnotation.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](siteDirectoryDataAnnotation.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](siteDirectoryDataAnnotation.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](siteDirectoryDataAnnotation.ModifiedOn));
             jsonObject.Add("primaryAnnotatedThing", this.PropertySerializerMap["primaryAnnotatedThing"](siteDirectoryDataAnnotation.PrimaryAnnotatedThing));
-            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](siteDirectoryDataAnnotation.RelatedThing));
+            jsonObject.Add("relatedThing", this.PropertySerializerMap["relatedThing"](siteDirectoryDataAnnotation.RelatedThing.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](siteDirectoryDataAnnotation.RevisionNumber));
             return jsonObject;
         }
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var siteDirectoryDataAnnotation = thing as SiteDirectoryDataAnnotation;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SiteDirectoryDataDiscussionItemSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SiteDirectoryDataDiscussionItemSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteDirectoryDataDiscussionItemSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SiteDirectoryDataDiscussionItemSerializer"/> class is to provide a <see cref="SiteDirectoryDataDiscussionItem"/> specific serializer
     /// </summary>
-    public class SiteDirectoryDataDiscussionItemSerializer : IThingSerializer
+    public class SiteDirectoryDataDiscussionItemSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -69,8 +68,8 @@ namespace CDP4JsonSerializer
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), siteDirectoryDataDiscussionItem.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](siteDirectoryDataDiscussionItem.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](siteDirectoryDataDiscussionItem.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteDirectoryDataDiscussionItem.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteDirectoryDataDiscussionItem.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteDirectoryDataDiscussionItem.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteDirectoryDataDiscussionItem.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](siteDirectoryDataDiscussionItem.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](siteDirectoryDataDiscussionItem.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](siteDirectoryDataDiscussionItem.ModifiedOn));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var siteDirectoryDataDiscussionItem = thing as SiteDirectoryDataDiscussionItem;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SiteDirectorySerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SiteDirectorySerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteDirectorySerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SiteDirectorySerializer"/> class is to provide a <see cref="SiteDirectory"/> specific serializer
     /// </summary>
-    public class SiteDirectorySerializer : IThingSerializer
+    public class SiteDirectorySerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -77,29 +76,29 @@ namespace CDP4JsonSerializer
         private JObject Serialize(SiteDirectory siteDirectory)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("annotation", this.PropertySerializerMap["annotation"](siteDirectory.Annotation));
+            jsonObject.Add("annotation", this.PropertySerializerMap["annotation"](siteDirectory.Annotation.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), siteDirectory.ClassKind)));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](siteDirectory.CreatedOn));
             jsonObject.Add("defaultParticipantRole", this.PropertySerializerMap["defaultParticipantRole"](siteDirectory.DefaultParticipantRole));
             jsonObject.Add("defaultPersonRole", this.PropertySerializerMap["defaultPersonRole"](siteDirectory.DefaultPersonRole));
-            jsonObject.Add("domain", this.PropertySerializerMap["domain"](siteDirectory.Domain));
-            jsonObject.Add("domainGroup", this.PropertySerializerMap["domainGroup"](siteDirectory.DomainGroup));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteDirectory.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteDirectory.ExcludedPerson));
+            jsonObject.Add("domain", this.PropertySerializerMap["domain"](siteDirectory.Domain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("domainGroup", this.PropertySerializerMap["domainGroup"](siteDirectory.DomainGroup.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteDirectory.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteDirectory.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](siteDirectory.Iid));
             jsonObject.Add("lastModifiedOn", this.PropertySerializerMap["lastModifiedOn"](siteDirectory.LastModifiedOn));
-            jsonObject.Add("logEntry", this.PropertySerializerMap["logEntry"](siteDirectory.LogEntry));
-            jsonObject.Add("model", this.PropertySerializerMap["model"](siteDirectory.Model));
+            jsonObject.Add("logEntry", this.PropertySerializerMap["logEntry"](siteDirectory.LogEntry.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("model", this.PropertySerializerMap["model"](siteDirectory.Model.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](siteDirectory.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](siteDirectory.Name));
-            jsonObject.Add("naturalLanguage", this.PropertySerializerMap["naturalLanguage"](siteDirectory.NaturalLanguage));
-            jsonObject.Add("organization", this.PropertySerializerMap["organization"](siteDirectory.Organization));
-            jsonObject.Add("participantRole", this.PropertySerializerMap["participantRole"](siteDirectory.ParticipantRole));
-            jsonObject.Add("person", this.PropertySerializerMap["person"](siteDirectory.Person));
-            jsonObject.Add("personRole", this.PropertySerializerMap["personRole"](siteDirectory.PersonRole));
+            jsonObject.Add("naturalLanguage", this.PropertySerializerMap["naturalLanguage"](siteDirectory.NaturalLanguage.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("organization", this.PropertySerializerMap["organization"](siteDirectory.Organization.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("participantRole", this.PropertySerializerMap["participantRole"](siteDirectory.ParticipantRole.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("person", this.PropertySerializerMap["person"](siteDirectory.Person.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("personRole", this.PropertySerializerMap["personRole"](siteDirectory.PersonRole.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](siteDirectory.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](siteDirectory.ShortName));
-            jsonObject.Add("siteReferenceDataLibrary", this.PropertySerializerMap["siteReferenceDataLibrary"](siteDirectory.SiteReferenceDataLibrary));
+            jsonObject.Add("siteReferenceDataLibrary", this.PropertySerializerMap["siteReferenceDataLibrary"](siteDirectory.SiteReferenceDataLibrary.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -120,7 +119,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var siteDirectory = thing as SiteDirectory;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SiteDirectoryThingReferenceSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SiteDirectoryThingReferenceSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteDirectoryThingReferenceSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SiteDirectoryThingReferenceSerializer"/> class is to provide a <see cref="SiteDirectoryThingReference"/> specific serializer
     /// </summary>
-    public class SiteDirectoryThingReferenceSerializer : IThingSerializer
+    public class SiteDirectoryThingReferenceSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,8 +62,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), siteDirectoryThingReference.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteDirectoryThingReference.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteDirectoryThingReference.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteDirectoryThingReference.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteDirectoryThingReference.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](siteDirectoryThingReference.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](siteDirectoryThingReference.ModifiedOn));
             jsonObject.Add("referencedRevisionNumber", this.PropertySerializerMap["referencedRevisionNumber"](siteDirectoryThingReference.ReferencedRevisionNumber));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var siteDirectoryThingReference = thing as SiteDirectoryThingReference;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SiteLogEntrySerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SiteLogEntrySerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteLogEntrySerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SiteLogEntrySerializer"/> class is to provide a <see cref="SiteLogEntry"/> specific serializer
     /// </summary>
-    public class SiteLogEntrySerializer : IThingSerializer
+    public class SiteLogEntrySerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,14 +66,14 @@ namespace CDP4JsonSerializer
         private JObject Serialize(SiteLogEntry siteLogEntry)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("affectedItemIid", this.PropertySerializerMap["affectedItemIid"](siteLogEntry.AffectedItemIid));
+            jsonObject.Add("affectedItemIid", this.PropertySerializerMap["affectedItemIid"](siteLogEntry.AffectedItemIid.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("author", this.PropertySerializerMap["author"](siteLogEntry.Author));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](siteLogEntry.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](siteLogEntry.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), siteLogEntry.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](siteLogEntry.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](siteLogEntry.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteLogEntry.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteLogEntry.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteLogEntry.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteLogEntry.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](siteLogEntry.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](siteLogEntry.LanguageCode));
             jsonObject.Add("level", this.PropertySerializerMap["level"](Enum.GetName(typeof(CDP4Common.CommonData.LogLevelKind), siteLogEntry.Level)));
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var siteLogEntry = thing as SiteLogEntry;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SiteReferenceDataLibrarySerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SiteReferenceDataLibrarySerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteReferenceDataLibrarySerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SiteReferenceDataLibrarySerializer"/> class is to provide a <see cref="SiteReferenceDataLibrary"/> specific serializer
     /// </summary>
-    public class SiteReferenceDataLibrarySerializer : IThingSerializer
+    public class SiteReferenceDataLibrarySerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -79,31 +78,31 @@ namespace CDP4JsonSerializer
         private JObject Serialize(SiteReferenceDataLibrary siteReferenceDataLibrary)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](siteReferenceDataLibrary.Alias));
-            jsonObject.Add("baseQuantityKind", this.PropertySerializerMap["baseQuantityKind"](siteReferenceDataLibrary.BaseQuantityKind));
-            jsonObject.Add("baseUnit", this.PropertySerializerMap["baseUnit"](siteReferenceDataLibrary.BaseUnit));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](siteReferenceDataLibrary.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("baseQuantityKind", this.PropertySerializerMap["baseQuantityKind"](siteReferenceDataLibrary.BaseQuantityKind.OrderBy(x => x, this.orderedItemComparer)));
+            jsonObject.Add("baseUnit", this.PropertySerializerMap["baseUnit"](siteReferenceDataLibrary.BaseUnit.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), siteReferenceDataLibrary.ClassKind)));
-            jsonObject.Add("constant", this.PropertySerializerMap["constant"](siteReferenceDataLibrary.Constant));
-            jsonObject.Add("definedCategory", this.PropertySerializerMap["definedCategory"](siteReferenceDataLibrary.DefinedCategory));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](siteReferenceDataLibrary.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteReferenceDataLibrary.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteReferenceDataLibrary.ExcludedPerson));
-            jsonObject.Add("fileType", this.PropertySerializerMap["fileType"](siteReferenceDataLibrary.FileType));
-            jsonObject.Add("glossary", this.PropertySerializerMap["glossary"](siteReferenceDataLibrary.Glossary));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](siteReferenceDataLibrary.HyperLink));
+            jsonObject.Add("constant", this.PropertySerializerMap["constant"](siteReferenceDataLibrary.Constant.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("definedCategory", this.PropertySerializerMap["definedCategory"](siteReferenceDataLibrary.DefinedCategory.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](siteReferenceDataLibrary.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](siteReferenceDataLibrary.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](siteReferenceDataLibrary.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("fileType", this.PropertySerializerMap["fileType"](siteReferenceDataLibrary.FileType.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("glossary", this.PropertySerializerMap["glossary"](siteReferenceDataLibrary.Glossary.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](siteReferenceDataLibrary.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](siteReferenceDataLibrary.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](siteReferenceDataLibrary.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](siteReferenceDataLibrary.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](siteReferenceDataLibrary.Name));
-            jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](siteReferenceDataLibrary.ParameterType));
-            jsonObject.Add("referenceSource", this.PropertySerializerMap["referenceSource"](siteReferenceDataLibrary.ReferenceSource));
+            jsonObject.Add("parameterType", this.PropertySerializerMap["parameterType"](siteReferenceDataLibrary.ParameterType.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("referenceSource", this.PropertySerializerMap["referenceSource"](siteReferenceDataLibrary.ReferenceSource.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("requiredRdl", this.PropertySerializerMap["requiredRdl"](siteReferenceDataLibrary.RequiredRdl));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](siteReferenceDataLibrary.RevisionNumber));
-            jsonObject.Add("rule", this.PropertySerializerMap["rule"](siteReferenceDataLibrary.Rule));
-            jsonObject.Add("scale", this.PropertySerializerMap["scale"](siteReferenceDataLibrary.Scale));
+            jsonObject.Add("rule", this.PropertySerializerMap["rule"](siteReferenceDataLibrary.Rule.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("scale", this.PropertySerializerMap["scale"](siteReferenceDataLibrary.Scale.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](siteReferenceDataLibrary.ShortName));
-            jsonObject.Add("unit", this.PropertySerializerMap["unit"](siteReferenceDataLibrary.Unit));
-            jsonObject.Add("unitPrefix", this.PropertySerializerMap["unitPrefix"](siteReferenceDataLibrary.UnitPrefix));
+            jsonObject.Add("unit", this.PropertySerializerMap["unit"](siteReferenceDataLibrary.Unit.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("unitPrefix", this.PropertySerializerMap["unitPrefix"](siteReferenceDataLibrary.UnitPrefix.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -124,7 +123,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var siteReferenceDataLibrary = thing as SiteReferenceDataLibrary;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SolutionSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SolutionSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SolutionSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SolutionSerializer"/> class is to provide a <see cref="Solution"/> specific serializer
     /// </summary>
-    public class SolutionSerializer : IThingSerializer
+    public class SolutionSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -69,8 +68,8 @@ namespace CDP4JsonSerializer
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), solution.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](solution.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](solution.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](solution.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](solution.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](solution.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](solution.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](solution.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](solution.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](solution.ModifiedOn));
@@ -96,7 +95,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var solution = thing as Solution;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/SpecializedQuantityKindSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/SpecializedQuantityKindSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SpecializedQuantityKindSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="SpecializedQuantityKindSerializer"/> class is to provide a <see cref="SpecializedQuantityKind"/> specific serializer
     /// </summary>
-    public class SpecializedQuantityKindSerializer : IThingSerializer
+    public class SpecializedQuantityKindSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -72,20 +71,20 @@ namespace CDP4JsonSerializer
         private JObject Serialize(SpecializedQuantityKind specializedQuantityKind)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](specializedQuantityKind.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](specializedQuantityKind.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](specializedQuantityKind.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](specializedQuantityKind.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), specializedQuantityKind.ClassKind)));
             jsonObject.Add("defaultScale", this.PropertySerializerMap["defaultScale"](specializedQuantityKind.DefaultScale));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](specializedQuantityKind.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](specializedQuantityKind.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](specializedQuantityKind.ExcludedPerson));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](specializedQuantityKind.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](specializedQuantityKind.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](specializedQuantityKind.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("general", this.PropertySerializerMap["general"](specializedQuantityKind.General));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](specializedQuantityKind.HyperLink));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](specializedQuantityKind.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](specializedQuantityKind.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](specializedQuantityKind.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](specializedQuantityKind.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](specializedQuantityKind.Name));
-            jsonObject.Add("possibleScale", this.PropertySerializerMap["possibleScale"](specializedQuantityKind.PossibleScale));
+            jsonObject.Add("possibleScale", this.PropertySerializerMap["possibleScale"](specializedQuantityKind.PossibleScale.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("quantityDimensionSymbol", this.PropertySerializerMap["quantityDimensionSymbol"](specializedQuantityKind.QuantityDimensionSymbol));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](specializedQuantityKind.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](specializedQuantityKind.ShortName));
@@ -110,7 +109,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var specializedQuantityKind = thing as SpecializedQuantityKind;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/StakeHolderValueMapSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/StakeHolderValueMapSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="StakeHolderValueMapSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="StakeHolderValueMapSerializer"/> class is to provide a <see cref="StakeHolderValueMap"/> specific serializer
     /// </summary>
-    public class StakeHolderValueMapSerializer : IThingSerializer
+    public class StakeHolderValueMapSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -71,23 +70,23 @@ namespace CDP4JsonSerializer
         private JObject Serialize(StakeHolderValueMap stakeHolderValueMap)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](stakeHolderValueMap.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](stakeHolderValueMap.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](stakeHolderValueMap.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](stakeHolderValueMap.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), stakeHolderValueMap.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](stakeHolderValueMap.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](stakeHolderValueMap.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](stakeHolderValueMap.ExcludedPerson));
-            jsonObject.Add("goal", this.PropertySerializerMap["goal"](stakeHolderValueMap.Goal));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](stakeHolderValueMap.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](stakeHolderValueMap.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](stakeHolderValueMap.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](stakeHolderValueMap.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("goal", this.PropertySerializerMap["goal"](stakeHolderValueMap.Goal.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](stakeHolderValueMap.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](stakeHolderValueMap.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](stakeHolderValueMap.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](stakeHolderValueMap.Name));
-            jsonObject.Add("requirement", this.PropertySerializerMap["requirement"](stakeHolderValueMap.Requirement));
+            jsonObject.Add("requirement", this.PropertySerializerMap["requirement"](stakeHolderValueMap.Requirement.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](stakeHolderValueMap.RevisionNumber));
-            jsonObject.Add("settings", this.PropertySerializerMap["settings"](stakeHolderValueMap.Settings));
+            jsonObject.Add("settings", this.PropertySerializerMap["settings"](stakeHolderValueMap.Settings.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](stakeHolderValueMap.ShortName));
-            jsonObject.Add("stakeholderValue", this.PropertySerializerMap["stakeholderValue"](stakeHolderValueMap.StakeholderValue));
-            jsonObject.Add("valueGroup", this.PropertySerializerMap["valueGroup"](stakeHolderValueMap.ValueGroup));
+            jsonObject.Add("stakeholderValue", this.PropertySerializerMap["stakeholderValue"](stakeHolderValueMap.StakeholderValue.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("valueGroup", this.PropertySerializerMap["valueGroup"](stakeHolderValueMap.ValueGroup.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -108,7 +107,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var stakeHolderValueMap = thing as StakeHolderValueMap;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/StakeHolderValueMapSettingsSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/StakeHolderValueMapSettingsSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="StakeHolderValueMapSettingsSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="StakeHolderValueMapSettingsSerializer"/> class is to provide a <see cref="StakeHolderValueMapSettings"/> specific serializer
     /// </summary>
-    public class StakeHolderValueMapSettingsSerializer : IThingSerializer
+    public class StakeHolderValueMapSettingsSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -64,8 +63,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), stakeHolderValueMapSettings.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](stakeHolderValueMapSettings.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](stakeHolderValueMapSettings.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](stakeHolderValueMapSettings.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](stakeHolderValueMapSettings.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("goalToValueGroupRelationship", this.PropertySerializerMap["goalToValueGroupRelationship"](stakeHolderValueMapSettings.GoalToValueGroupRelationship));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](stakeHolderValueMapSettings.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](stakeHolderValueMapSettings.ModifiedOn));
@@ -92,7 +91,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var stakeHolderValueMapSettings = thing as StakeHolderValueMapSettings;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/StakeholderSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/StakeholderSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="StakeholderSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="StakeholderSerializer"/> class is to provide a <see cref="Stakeholder"/> specific serializer
     /// </summary>
-    public class StakeholderSerializer : IThingSerializer
+    public class StakeholderSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,19 +66,19 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Stakeholder stakeholder)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](stakeholder.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](stakeholder.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](stakeholder.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](stakeholder.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), stakeholder.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](stakeholder.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](stakeholder.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](stakeholder.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](stakeholder.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](stakeholder.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](stakeholder.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](stakeholder.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](stakeholder.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](stakeholder.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](stakeholder.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](stakeholder.Name));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](stakeholder.RevisionNumber));
             jsonObject.Add("shortName", this.PropertySerializerMap["shortName"](stakeholder.ShortName));
-            jsonObject.Add("stakeholderValue", this.PropertySerializerMap["stakeholderValue"](stakeholder.StakeholderValue));
+            jsonObject.Add("stakeholderValue", this.PropertySerializerMap["stakeholderValue"](stakeholder.StakeholderValue.OrderBy(x => x, this.guidComparer)));
             return jsonObject;
         }
 
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var stakeholder = thing as Stakeholder;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/StakeholderValueSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/StakeholderValueSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="StakeholderValueSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="StakeholderValueSerializer"/> class is to provide a <see cref="StakeholderValue"/> specific serializer
     /// </summary>
-    public class StakeholderValueSerializer : IThingSerializer
+    public class StakeholderValueSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,13 +65,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(StakeholderValue stakeholderValue)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](stakeholderValue.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](stakeholderValue.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](stakeholderValue.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](stakeholderValue.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), stakeholderValue.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](stakeholderValue.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](stakeholderValue.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](stakeholderValue.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](stakeholderValue.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](stakeholderValue.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](stakeholderValue.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](stakeholderValue.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](stakeholderValue.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](stakeholderValue.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](stakeholderValue.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](stakeholderValue.Name));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var stakeholderValue = thing as StakeholderValue;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/TelephoneNumberSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/TelephoneNumberSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TelephoneNumberSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="TelephoneNumberSerializer"/> class is to provide a <see cref="TelephoneNumber"/> specific serializer
     /// </summary>
-    public class TelephoneNumberSerializer : IThingSerializer
+    public class TelephoneNumberSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,8 +62,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), telephoneNumber.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](telephoneNumber.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](telephoneNumber.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](telephoneNumber.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](telephoneNumber.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](telephoneNumber.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](telephoneNumber.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](telephoneNumber.RevisionNumber));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var telephoneNumber = thing as TelephoneNumber;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/TermSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/TermSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TermSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="TermSerializer"/> class is to provide a <see cref="Term"/> specific serializer
     /// </summary>
-    public class TermSerializer : IThingSerializer
+    public class TermSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,12 +65,12 @@ namespace CDP4JsonSerializer
         private JObject Serialize(Term term)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](term.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](term.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), term.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](term.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](term.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](term.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](term.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](term.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](term.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](term.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](term.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](term.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](term.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](term.ModifiedOn));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var term = thing as Term;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/TextParameterTypeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/TextParameterTypeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TextParameterTypeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="TextParameterTypeSerializer"/> class is to provide a <see cref="TextParameterType"/> specific serializer
     /// </summary>
-    public class TextParameterTypeSerializer : IThingSerializer
+    public class TextParameterTypeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,13 +67,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(TextParameterType textParameterType)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](textParameterType.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](textParameterType.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](textParameterType.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](textParameterType.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), textParameterType.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](textParameterType.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](textParameterType.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](textParameterType.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](textParameterType.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](textParameterType.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](textParameterType.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](textParameterType.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](textParameterType.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](textParameterType.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](textParameterType.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](textParameterType.ModifiedOn));
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var textParameterType = thing as TextParameterType;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/TextualNoteSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/TextualNoteSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TextualNoteSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="TextualNoteSerializer"/> class is to provide a <see cref="TextualNote"/> specific serializer
     /// </summary>
-    public class TextualNoteSerializer : IThingSerializer
+    public class TextualNoteSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,12 +66,12 @@ namespace CDP4JsonSerializer
         private JObject Serialize(TextualNote textualNote)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("category", this.PropertySerializerMap["category"](textualNote.Category));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](textualNote.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), textualNote.ClassKind)));
             jsonObject.Add("content", this.PropertySerializerMap["content"](textualNote.Content));
             jsonObject.Add("createdOn", this.PropertySerializerMap["createdOn"](textualNote.CreatedOn));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](textualNote.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](textualNote.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](textualNote.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](textualNote.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](textualNote.Iid));
             jsonObject.Add("languageCode", this.PropertySerializerMap["languageCode"](textualNote.LanguageCode));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](textualNote.ModifiedOn));
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var textualNote = thing as TextualNote;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/TimeOfDayParameterTypeSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/TimeOfDayParameterTypeSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TimeOfDayParameterTypeSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="TimeOfDayParameterTypeSerializer"/> class is to provide a <see cref="TimeOfDayParameterType"/> specific serializer
     /// </summary>
-    public class TimeOfDayParameterTypeSerializer : IThingSerializer
+    public class TimeOfDayParameterTypeSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -68,13 +67,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(TimeOfDayParameterType timeOfDayParameterType)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](timeOfDayParameterType.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](timeOfDayParameterType.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](timeOfDayParameterType.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](timeOfDayParameterType.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), timeOfDayParameterType.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](timeOfDayParameterType.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](timeOfDayParameterType.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](timeOfDayParameterType.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](timeOfDayParameterType.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](timeOfDayParameterType.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](timeOfDayParameterType.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](timeOfDayParameterType.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](timeOfDayParameterType.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](timeOfDayParameterType.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](timeOfDayParameterType.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](timeOfDayParameterType.ModifiedOn));
@@ -102,7 +101,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var timeOfDayParameterType = thing as TimeOfDayParameterType;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/UnitFactorSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/UnitFactorSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="UnitFactorSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="UnitFactorSerializer"/> class is to provide a <see cref="UnitFactor"/> specific serializer
     /// </summary>
-    public class UnitFactorSerializer : IThingSerializer
+    public class UnitFactorSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,8 +62,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), unitFactor.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](unitFactor.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](unitFactor.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](unitFactor.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](unitFactor.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("exponent", this.PropertySerializerMap["exponent"](unitFactor.Exponent));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](unitFactor.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](unitFactor.ModifiedOn));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var unitFactor = thing as UnitFactor;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/UnitPrefixSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/UnitPrefixSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="UnitPrefixSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="UnitPrefixSerializer"/> class is to provide a <see cref="UnitPrefix"/> specific serializer
     /// </summary>
-    public class UnitPrefixSerializer : IThingSerializer
+    public class UnitPrefixSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -67,13 +66,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(UnitPrefix unitPrefix)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](unitPrefix.Alias));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](unitPrefix.Alias.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), unitPrefix.ClassKind)));
             jsonObject.Add("conversionFactor", this.PropertySerializerMap["conversionFactor"](unitPrefix.ConversionFactor));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](unitPrefix.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](unitPrefix.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](unitPrefix.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](unitPrefix.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](unitPrefix.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](unitPrefix.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](unitPrefix.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](unitPrefix.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](unitPrefix.Iid));
             jsonObject.Add("isDeprecated", this.PropertySerializerMap["isDeprecated"](unitPrefix.IsDeprecated));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](unitPrefix.ModifiedOn));
@@ -100,7 +99,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var unitPrefix = thing as UnitPrefix;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/UserPreferenceSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/UserPreferenceSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="UserPreferenceSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="UserPreferenceSerializer"/> class is to provide a <see cref="UserPreference"/> specific serializer
     /// </summary>
-    public class UserPreferenceSerializer : IThingSerializer
+    public class UserPreferenceSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -63,8 +62,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), userPreference.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](userPreference.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](userPreference.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](userPreference.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](userPreference.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](userPreference.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](userPreference.ModifiedOn));
             jsonObject.Add("revisionNumber", this.PropertySerializerMap["revisionNumber"](userPreference.RevisionNumber));
@@ -90,7 +89,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var userPreference = thing as UserPreference;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/UserRuleVerificationSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/UserRuleVerificationSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="UserRuleVerificationSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="UserRuleVerificationSerializer"/> class is to provide a <see cref="UserRuleVerification"/> specific serializer
     /// </summary>
-    public class UserRuleVerificationSerializer : IThingSerializer
+    public class UserRuleVerificationSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -65,8 +64,8 @@ namespace CDP4JsonSerializer
         {
             var jsonObject = new JObject();
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), userRuleVerification.ClassKind)));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](userRuleVerification.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](userRuleVerification.ExcludedPerson));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](userRuleVerification.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](userRuleVerification.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("executedOn", this.PropertySerializerMap["executedOn"](userRuleVerification.ExecutedOn));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](userRuleVerification.Iid));
             jsonObject.Add("isActive", this.PropertySerializerMap["isActive"](userRuleVerification.IsActive));
@@ -94,7 +93,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var userRuleVerification = thing as UserRuleVerification;

--- a/CDP4JsonSerializer/AutoGenDtoSerializer/ValueGroupSerializer.cs
+++ b/CDP4JsonSerializer/AutoGenDtoSerializer/ValueGroupSerializer.cs
@@ -1,11 +1,11 @@
-#region Copyright
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ValueGroupSerializer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2018 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam GerenÃ©, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
 //
 //    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {
@@ -33,11 +32,11 @@ namespace CDP4JsonSerializer
     using CDP4Common.DTO;
     using CDP4Common.Types;
     using Newtonsoft.Json.Linq;
-    
+
     /// <summary>
     /// The purpose of the <see cref="ValueGroupSerializer"/> class is to provide a <see cref="ValueGroup"/> specific serializer
     /// </summary>
-    public class ValueGroupSerializer : IThingSerializer
+    public class ValueGroupSerializer : BaseThingSerializer, IThingSerializer
     {
         /// <summary>
         /// The map containing the serialization methods
@@ -66,13 +65,13 @@ namespace CDP4JsonSerializer
         private JObject Serialize(ValueGroup valueGroup)
         {
             var jsonObject = new JObject();
-            jsonObject.Add("alias", this.PropertySerializerMap["alias"](valueGroup.Alias));
-            jsonObject.Add("category", this.PropertySerializerMap["category"](valueGroup.Category));
+            jsonObject.Add("alias", this.PropertySerializerMap["alias"](valueGroup.Alias.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("category", this.PropertySerializerMap["category"](valueGroup.Category.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("classKind", this.PropertySerializerMap["classKind"](Enum.GetName(typeof(CDP4Common.CommonData.ClassKind), valueGroup.ClassKind)));
-            jsonObject.Add("definition", this.PropertySerializerMap["definition"](valueGroup.Definition));
-            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](valueGroup.ExcludedDomain));
-            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](valueGroup.ExcludedPerson));
-            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](valueGroup.HyperLink));
+            jsonObject.Add("definition", this.PropertySerializerMap["definition"](valueGroup.Definition.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedDomain", this.PropertySerializerMap["excludedDomain"](valueGroup.ExcludedDomain.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("excludedPerson", this.PropertySerializerMap["excludedPerson"](valueGroup.ExcludedPerson.OrderBy(x => x, this.guidComparer)));
+            jsonObject.Add("hyperLink", this.PropertySerializerMap["hyperLink"](valueGroup.HyperLink.OrderBy(x => x, this.guidComparer)));
             jsonObject.Add("iid", this.PropertySerializerMap["iid"](valueGroup.Iid));
             jsonObject.Add("modifiedOn", this.PropertySerializerMap["modifiedOn"](valueGroup.ModifiedOn));
             jsonObject.Add("name", this.PropertySerializerMap["name"](valueGroup.Name));
@@ -98,7 +97,7 @@ namespace CDP4JsonSerializer
         {
             if (thing == null)
             {
-                throw new ArgumentNullException("thing");
+                throw new ArgumentNullException($"The {nameof(thing)} may not be null.", nameof(thing));
             }
 
             var valueGroup = thing as ValueGroup;

--- a/CDP4JsonSerializer/CDP4JsonSerializer.csproj
+++ b/CDP4JsonSerializer/CDP4JsonSerializer.csproj
@@ -36,7 +36,6 @@
   <ItemGroup>
     <Folder Include="AutoGenDtoDeserializer\" />
     <Folder Include="AutoGenDtoSerializer\" />
-    <Folder Include="DtoSerializer\" />
     <Folder Include="Helper\" />
     <Folder Include="JsonConverter\" />
   </ItemGroup>

--- a/CDP4JsonSerializer/DtoSerializer/BaseThingSerializer.cs
+++ b/CDP4JsonSerializer/DtoSerializer/BaseThingSerializer.cs
@@ -1,0 +1,46 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ThingSerializer.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4JsonSerializer
+{
+    using System;
+    using CDP4Common.Comparers;
+    using CDP4Common.Types;
+
+    /// <summary>
+    /// Abstract supertype from which all <see cref="BaseThingSerializer"/> derive
+    /// </summary>
+    public abstract class BaseThingSerializer
+    {
+        /// <summary>
+        /// The <see cref="GuidComparer"/> used to compare 2 <see cref="Guid"/>s
+        /// </summary>
+        protected readonly GuidComparer guidComparer = new GuidComparer();
+
+        /// <summary>
+        /// The <see cref="OrderedItemComparer"/> used to compare 2 <see cref="OrderedItem"/>s
+        /// </summary>
+        protected readonly OrderedItemComparer orderedItemComparer = new OrderedItemComparer();
+    }
+}

--- a/CDP4JsonSerializer/DtoSerializer/IThingSerializer.cs
+++ b/CDP4JsonSerializer/DtoSerializer/IThingSerializer.cs
@@ -1,9 +1,8 @@
-﻿#region Copyright
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IThingSerializer.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -22,7 +21,6 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer
 {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x ] I have provided test coverage for my change (where applicable)

### Description
  - Generated serializers that make sure List<Guid> and OrderItemList<> properties are serialized in a stable fashion
  - changed line endings of generated files from /n to /r/n (windows compatible) -> this makes reviewing in the browser not so easy as all lines in all files are now marked as changed. A diff with git extensions, setting it to ignorare whitespace changes at end of line gives a better view of changes

<!-- Thanks for contributing to CDP4-SDK! -->