### PR TITLE
Bugfix MODIFY_IF_OWNED fixes GH80

### DIFF
--- a/CDP4Dal.NetCore.Tests/Permission/PermissionServiceTestFixture.cs
+++ b/CDP4Dal.NetCore.Tests/Permission/PermissionServiceTestFixture.cs
@@ -3,7 +3,7 @@
 // <copyright file="PermissionServiceTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -31,6 +31,7 @@ namespace CDP4Dal.Tests.Permission
     using System.Linq;
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.Exceptions;
     using CDP4Common.SiteDirectoryData;
     using CDP4Dal.Permission;
     using CDP4Dal.DAL;
@@ -62,8 +63,11 @@ namespace CDP4Dal.Tests.Permission
         private BinaryRelationship relationship;
         private Parameter parameter;
         private ParameterValueSet valueset;
+        private Requirement requirement;
+        private RequirementsSpecification requirementsSpecification;
 
         private PermissionService permissionService;
+        private CommonFileStore commonFileStore;
 
         [SetUp]
         public void Setup()
@@ -84,8 +88,8 @@ namespace CDP4Dal.Tests.Permission
             this.personRole = new PersonRole(Guid.NewGuid(), this.assembler.Cache, this.uri);
             this.participant = new Participant(Guid.NewGuid(), this.assembler.Cache, this.uri);
             this.participantRole = new ParticipantRole(Guid.NewGuid(), this.assembler.Cache, this.uri);
-            this.model = new EngineeringModel(Guid.NewGuid(), this.assembler.Cache, this.uri){EngineeringModelSetup = this.modelsetup};
-            this.iteration = new Iteration(Guid.NewGuid(), this.assembler.Cache, this.uri){IterationSetup = this.iterationSetup};
+            this.model = new EngineeringModel(Guid.NewGuid(), this.assembler.Cache, this.uri) { EngineeringModelSetup = this.modelsetup };
+            this.iteration = new Iteration(Guid.NewGuid(), this.assembler.Cache, this.uri) { IterationSetup = this.iterationSetup };
             this.definition = new Definition(Guid.NewGuid(), this.assembler.Cache, this.uri);
             this.srdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             this.booleanpt = new BooleanParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri);
@@ -94,6 +98,9 @@ namespace CDP4Dal.Tests.Permission
             this.relationship = new BinaryRelationship(Guid.NewGuid(), this.assembler.Cache, this.uri);
             this.parameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri);
             this.valueset = new ParameterValueSet(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            this.requirementsSpecification = new RequirementsSpecification(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            this.requirement = new Requirement(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            this.commonFileStore = new CommonFileStore(Guid.NewGuid(), this.assembler.Cache, this.uri);
 
             this.sitedir.Model.Add(this.modelsetup);
             this.sitedir.Person.Add(this.person);
@@ -120,10 +127,15 @@ namespace CDP4Dal.Tests.Permission
             this.modelsetup.EngineeringModelIid = this.model.Iid;
             this.iterationSetup.IterationIid = this.iteration.Iid;
             this.elementDef.Owner = this.domain1;
+            this.relationship.Owner = this.domain1;
+            this.parameter.Owner = this.domain1;
+            this.requirementsSpecification.Requirement.Add(this.requirement);
+            this.iteration.RequirementsSpecification.Add(this.requirementsSpecification);
+            this.model.CommonFileStore.Add(this.commonFileStore);
 
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
-            this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise,Participant>>
+            this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>
             {
                 {this.iteration, new Tuple<DomainOfExpertise,Participant>(this.domain1,this.participant)}
             });
@@ -248,7 +260,7 @@ namespace CDP4Dal.Tests.Permission
         [Test]
         public void VerifyThatReadWriteIfParticipantWorks()
         {
-            this.session.Setup(x => x.ActivePersonParticipants).Returns(new List<Participant> {this.participant});
+            this.session.Setup(x => x.ActivePersonParticipants).Returns(new List<Participant> { this.participant });
 
             var sdpermission = this.personRole.PersonPermission.Single(x => x.ObjectClass == ClassKind.SiteDirectory);
             sdpermission.AccessRight = PersonAccessRightKind.READ_IF_PARTICIPANT;
@@ -289,7 +301,7 @@ namespace CDP4Dal.Tests.Permission
         }
 
         [Test]
-        public void VerifyModifyIfOwner()
+        public void VerifyModifyIfOwnerForIterationsWithoutDomainOfExpertiseAndParticipant()
         {
             this.session.Setup(x => x.ActivePersonParticipants).Returns(new List<Participant> { this.participant });
             Assert.IsFalse(this.permissionService.CanWrite(this.model));
@@ -298,7 +310,7 @@ namespace CDP4Dal.Tests.Permission
             var permission =
                 this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.EngineeringModel);
             var defpermission =
-               this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.ElementDefinition);
+                this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.ElementDefinition);
 
             permission.AccessRight = ParticipantAccessRightKind.MODIFY_IF_OWNER;
             defpermission.AccessRight = ParticipantAccessRightKind.MODIFY_IF_OWNER;
@@ -317,6 +329,80 @@ namespace CDP4Dal.Tests.Permission
             Assert.IsFalse(this.permissionService.CanWrite(this.elementDef));
             Assert.IsTrue(this.permissionService.CanRead(this.elementDef));
         }
+
+        [Test]
+        public void VerifyModifyIfOwnerForRequirement()
+        {
+            this.session.Setup(x => x.ActivePersonParticipants).Returns(new List<Participant> { this.participant });
+            Assert.IsFalse(this.permissionService.CanWrite(this.model));
+            Assert.IsFalse(this.permissionService.CanRead(this.model));
+
+            var permission =
+                this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.Requirement);
+            var specPermission =
+                this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.RequirementsSpecification);
+
+            permission.AccessRight = ParticipantAccessRightKind.MODIFY_IF_OWNER;
+            specPermission.AccessRight = ParticipantAccessRightKind.MODIFY;
+
+            //Requirement has no owner
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanWrite(this.requirement));
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanRead(this.requirement));
+
+            //RequirementsSpecification has no owner
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanWrite(this.requirementsSpecification));
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanRead(this.requirementsSpecification));
+
+            //Requirement has same owner than user's domain of expertise
+            this.requirement.Owner = this.domain1;
+            Assert.IsTrue(this.permissionService.CanWrite(this.requirement));
+            Assert.IsTrue(this.permissionService.CanRead(this.requirement));
+
+            //Requirement has other owner than user's domain of expertise
+            this.requirement.Owner = this.domain2;
+            Assert.IsFalse(this.permissionService.CanWrite(this.requirement));
+            Assert.IsTrue(this.permissionService.CanRead(this.requirement));
+
+            //RequirementsSepcification has same owner than user's domain of expertise
+            this.requirementsSpecification.Owner = this.domain1;
+            specPermission.AccessRight = ParticipantAccessRightKind.MODIFY_IF_OWNER;
+            Assert.IsTrue(this.permissionService.CanWrite(this.requirementsSpecification));
+            Assert.IsTrue(this.permissionService.CanRead(this.requirementsSpecification));
+
+            //RequirementsSepcification has other owner than user's domain of expertise
+            this.requirementsSpecification.Owner = this.domain2;
+            Assert.IsFalse(this.permissionService.CanWrite(this.requirementsSpecification));
+            Assert.IsTrue(this.permissionService.CanRead(this.requirementsSpecification));
+
+        }
+
+        [Test]
+        public void VerifyModifyIfOwnerForThingsThatAreDirectlyUnderEngineeringModel()
+        {
+            this.session.Setup(x => x.ActivePersonParticipants).Returns(new List<Participant> { this.participant });
+            Assert.IsFalse(this.permissionService.CanWrite(this.model));
+            Assert.IsFalse(this.permissionService.CanRead(this.model));
+
+            var permission =
+                this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.CommonFileStore);
+
+            permission.AccessRight = ParticipantAccessRightKind.MODIFY_IF_OWNER;
+
+            //Thing has no owner
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanWrite(this.commonFileStore));
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanRead(this.commonFileStore));
+
+            //Thing has same owner as User's participant
+            this.commonFileStore.Owner = this.domain1;
+            Assert.IsTrue(this.permissionService.CanWrite(this.commonFileStore));
+            Assert.IsTrue(this.permissionService.CanRead(this.commonFileStore));
+
+            //Thing has other owner as User's participant
+            this.commonFileStore.Owner = this.domain2;
+            Assert.IsTrue(this.permissionService.CanWrite(this.commonFileStore));
+            Assert.IsTrue(this.permissionService.CanRead(this.commonFileStore));
+        }
+
 
         [Test]
         public void VerifySameAsSuperclassParticipantPermission()
@@ -339,7 +425,7 @@ namespace CDP4Dal.Tests.Permission
             Assert.IsFalse(this.permissionService.CanWrite(this.valueset));
             Assert.IsFalse(this.permissionService.CanRead(this.valueset));
 
-            var permission =this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.Parameter);
+            var permission = this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.Parameter);
 
             permission.AccessRight = ParticipantAccessRightKind.MODIFY;
             Assert.IsTrue(this.permissionService.CanWrite(this.valueset));

--- a/CDP4Dal.Tests/Permission/PermissionServiceTestFixture.cs
+++ b/CDP4Dal.Tests/Permission/PermissionServiceTestFixture.cs
@@ -31,6 +31,7 @@ namespace CDP4Dal.Tests.Permission
     using System.Linq;
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.Exceptions;
     using CDP4Common.SiteDirectoryData;
     using CDP4Dal.Permission;
     using CDP4Dal.DAL;
@@ -126,6 +127,8 @@ namespace CDP4Dal.Tests.Permission
             this.modelsetup.EngineeringModelIid = this.model.Iid;
             this.iterationSetup.IterationIid = this.iteration.Iid;
             this.elementDef.Owner = this.domain1;
+            this.relationship.Owner = this.domain1;
+            this.parameter.Owner = this.domain1;
             this.requirementsSpecification.Requirement.Add(this.requirement);
             this.iteration.RequirementsSpecification.Add(this.requirementsSpecification);
             this.model.CommonFileStore.Add(this.commonFileStore);
@@ -343,15 +346,15 @@ namespace CDP4Dal.Tests.Permission
             specPermission.AccessRight = ParticipantAccessRightKind.MODIFY;
 
             //Requirement has no owner
-            Assert.IsFalse(this.permissionService.CanWrite(this.requirement));
-            Assert.IsTrue(this.permissionService.CanRead(this.requirement));
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanWrite(this.requirement));
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanRead(this.requirement));
+
+            //RequirementsSpecification has no owner
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanWrite(this.requirementsSpecification));
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanRead(this.requirementsSpecification));
 
             //Requirement has same owner than user's domain of expertise
             this.requirement.Owner = this.domain1;
-            Assert.IsTrue(this.permissionService.CanWrite(this.requirementsSpecification));
-            Assert.IsTrue(this.permissionService.CanRead(this.requirementsSpecification));
-
-            //RequirementsSpecification has no owner
             Assert.IsTrue(this.permissionService.CanWrite(this.requirement));
             Assert.IsTrue(this.permissionService.CanRead(this.requirement));
 
@@ -386,8 +389,8 @@ namespace CDP4Dal.Tests.Permission
             permission.AccessRight = ParticipantAccessRightKind.MODIFY_IF_OWNER;
 
             //Thing has no owner
-            Assert.IsTrue(this.permissionService.CanWrite(this.commonFileStore));
-            Assert.IsTrue(this.permissionService.CanRead(this.commonFileStore));
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanWrite(this.commonFileStore));
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanRead(this.commonFileStore));
 
             //Thing has same owner as User's participant
             this.commonFileStore.Owner = this.domain1;

--- a/CDP4Dal/Permission/PermissionService.cs
+++ b/CDP4Dal/Permission/PermissionService.cs
@@ -3,7 +3,7 @@
 // <copyright file="PermissionService.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -112,7 +112,7 @@ namespace CDP4Dal.Permission
                 this.Session.ActivePersonParticipants.FirstOrDefault(
                     p => ((EngineeringModelSetup)p.Container).EngineeringModelIid == engineeringModel.Iid);
 
-            if (participant == null || participant.Role == null)
+            if (participant?.Role == null)
             {
                 return false;
             }
@@ -122,16 +122,14 @@ namespace CDP4Dal.Permission
 
             if (thing.GetType() != thingType)
             {
-                ClassKind superClassKind;
-
-                if (Enum.TryParse(thingType.Name, out superClassKind))
+                if (Enum.TryParse(thingType.Name, out ClassKind superClassKind))
                 {
                     permission = participant.Role.ParticipantPermission.SingleOrDefault(perm => perm.ObjectClass == superClassKind);
                 }
             }
 
             // if the permission is not found then get the default one.
-            var accessRightKind = permission == null ? StaticDefaultPermissionProvider.GetDefaultParticipantPermission(thingType.Name) : permission.AccessRight;
+            var accessRightKind = permission?.AccessRight ?? StaticDefaultPermissionProvider.GetDefaultParticipantPermission(thingType.Name);
 
             switch (accessRightKind)
             {
@@ -175,16 +173,14 @@ namespace CDP4Dal.Permission
 
             if (thing.GetType() != thingType)
             {
-                ClassKind superClassKind;
-
-                if (Enum.TryParse(thingType.Name, out superClassKind))
+                if (Enum.TryParse(thingType.Name, out ClassKind superClassKind))
                 {
                     permission = personRole.PersonPermission.SingleOrDefault(perm => perm.ObjectClass == superClassKind);
                 }
             }
 
             // if the permission is not found or superclass derivation is used then get the default one.
-            var accessRightKind = permission == null ? StaticDefaultPermissionProvider.GetDefaultPersonPermission(thingType.Name) : permission.AccessRight;
+            var accessRightKind = permission?.AccessRight ?? StaticDefaultPermissionProvider.GetDefaultPersonPermission(thingType.Name);
 
             switch (accessRightKind)
             {
@@ -299,14 +295,14 @@ namespace CDP4Dal.Permission
             var engineeringModel = thing.TopContainer;
 
             var iteration = thing is Iteration it ? it : thing.GetContainerOfType<Iteration>();
-            if (iteration!= null && iteration.IterationSetup.FrozenOn != null)
+            if (iteration?.IterationSetup.FrozenOn != null)
             {
                 return false;
             }
 
             var participant = this.Session.ActivePersonParticipants.FirstOrDefault(p => ((EngineeringModelSetup)p.Container).EngineeringModelIid == engineeringModel.Iid);
 
-            if (participant == null || participant.Role == null)
+            if (participant?.Role == null)
             {
                 return false;
             }
@@ -315,16 +311,14 @@ namespace CDP4Dal.Permission
 
             if (thing.GetType() != thingType)
             {
-                ClassKind superClassKind;
-
-                if (Enum.TryParse(thingType.Name, out superClassKind))
+                if (Enum.TryParse(thingType.Name, out ClassKind superClassKind))
                 {
                     permission = participant.Role.ParticipantPermission.SingleOrDefault(perm => perm.ObjectClass == superClassKind);
                 }
             }
 
             // if the permission is not found then get the default one.
-            var accessRightKind = permission == null ? StaticDefaultPermissionProvider.GetDefaultParticipantPermission(thingType.Name) : permission.AccessRight;
+            var accessRightKind = permission?.AccessRight ?? StaticDefaultPermissionProvider.GetDefaultParticipantPermission(thingType.Name);
 
             switch (accessRightKind)
             {
@@ -335,9 +329,8 @@ namespace CDP4Dal.Permission
                 case ParticipantAccessRightKind.MODIFY:
                     return true;
                 case ParticipantAccessRightKind.MODIFY_IF_OWNER:
-                    var ownedThing = thing as IOwnedThing;
 
-                    if (ownedThing != null)
+                    if (thing is IOwnedThing ownedThing)
                     {
                         return this.CanWriteIfParticipantOwned(ownedThing);
                     }
@@ -365,14 +358,14 @@ namespace CDP4Dal.Permission
 
             var iteration = containerThing is Iteration it ? it : containerThing.GetContainerOfType<Iteration>();
             
-            if (iteration != null && iteration.IterationSetup.FrozenOn != null)
+            if (iteration?.IterationSetup.FrozenOn != null)
             {
                 return false;
             }
 
             var participant = this.Session.ActivePersonParticipants.FirstOrDefault(p => ((EngineeringModelSetup)p.Container).EngineeringModelIid == engineeringModel.Iid);
 
-            if (participant == null || participant.Role == null)
+            if (participant?.Role == null)
             {
                 return false;
             }
@@ -380,7 +373,7 @@ namespace CDP4Dal.Permission
             var permission = participant.Role.ParticipantPermission.SingleOrDefault(perm => perm.ObjectClass == classKind);
 
             // if the permission is not found then get the default one.
-            var right = permission != null ? permission.AccessRight : StaticDefaultPermissionProvider.GetDefaultParticipantPermission(thingType.ToString());
+            var right = permission?.AccessRight ?? StaticDefaultPermissionProvider.GetDefaultParticipantPermission(thingType.ToString());
 
             switch (right)
             {
@@ -423,16 +416,14 @@ namespace CDP4Dal.Permission
 
             if (thing.GetType() != thingType)
             {
-                ClassKind superClassKind;
-
-                if (Enum.TryParse(thingType.Name, out superClassKind))
+                if (Enum.TryParse(thingType.Name, out ClassKind superClassKind))
                 {
                     permission = personRole.PersonPermission.SingleOrDefault(perm => perm.ObjectClass == superClassKind);
                 }
             }
 
             // if the permission is not found or superclass derivation is used then get the default one.
-            var accessRightKind = permission == null ? StaticDefaultPermissionProvider.GetDefaultPersonPermission(thingType.Name) : permission.AccessRight;
+            var accessRightKind = permission?.AccessRight ?? StaticDefaultPermissionProvider.GetDefaultPersonPermission(thingType.Name);
 
             switch (accessRightKind)
             {
@@ -491,7 +482,7 @@ namespace CDP4Dal.Permission
             var permission = personRole.PersonPermission.SingleOrDefault(p => p.ObjectClass == classKind);
 
             // if the permission is not found or superclass derivation is used then get the default one.
-            var accessRightKind = permission == null ? StaticDefaultPermissionProvider.GetDefaultPersonPermission(thingType.ToString()) : permission.AccessRight;
+            var accessRightKind = permission?.AccessRight ?? StaticDefaultPermissionProvider.GetDefaultPersonPermission(thingType.ToString());
 
             switch (accessRightKind)
             {
@@ -502,9 +493,8 @@ namespace CDP4Dal.Permission
                 case PersonAccessRightKind.MODIFY:
                     return true;
                 case PersonAccessRightKind.MODIFY_IF_PARTICIPANT:
-                    if (containerThing is EngineeringModelSetup)
+                    if (containerThing is EngineeringModelSetup setup)
                     {
-                        var setup = containerThing as EngineeringModelSetup;
                         return setup.Participant.Any(x => x.Person == this.Session.ActivePerson);
                     }
 
@@ -531,8 +521,7 @@ namespace CDP4Dal.Permission
         /// <param name="thingType">The <see cref="Type"/> of the <see cref="Thing"/> that will be write to.</param>
         /// <returns>True if the permissions of the superclass allow it.</returns>
         private bool CanWriteBasedOnSuperclassClassKind(Thing containerThing, ClassKind thingType)
-        { 
-            ClassKind superClassKind;
+        {
             var baseType = StaticMetadataProvider.BaseType(thingType.ToString());
 
             if (string.IsNullOrWhiteSpace(baseType))
@@ -540,7 +529,7 @@ namespace CDP4Dal.Permission
                 return false;
             }
 
-            return Enum.TryParse(baseType, out superClassKind) && this.CanWrite(superClassKind, containerThing);
+            return Enum.TryParse(baseType, out ClassKind superClassKind) && this.CanWrite(superClassKind, containerThing);
         }
 
         /// <summary>
@@ -552,35 +541,37 @@ namespace CDP4Dal.Permission
         {
             var thing = (Thing)ownedThing;
 
-            var iteration = thing is Iteration it ? it : thing.GetContainerOfType<Iteration>();
-
-            if (iteration == null || !this.Session.OpenIterations.TryGetValue(iteration, out var participation))
+            if (thing.Container is EngineeringModel currentModel)
             {
-                return false;
-            }
-
-            //Check if the iteration domain is null
-            if (participation.Item1 == null)
-            {
-                return false;
+                return this.Session.OpenIterations.Where(x => x.Key.Container == currentModel).Select(x => x.Value).Any();
             }
 
             //Check if the ownedThing domain is contained in the participant domains 
-            if (participation.Item2 != null)
+            return this.TryGetThingParticipant(thing, out var participant) 
+                   && participant.Domain.Contains(ownedThing.Owner);
+        }
+
+        /// <summary>
+        /// Try to get the user's 'participant information for the Iteration where the thing input parameter belongs to
+        /// </summary>
+        /// <param name="thing">General Thing for which the user's participant information is retrieved.</param>
+        /// <param name="participant">outgoing parameter that contains the user's <see cref="Participant"/> information.</param>
+        /// <returns></returns>
+        private bool TryGetThingParticipant(Thing thing, out Participant participant)
+        {
+            var iteration = thing is Iteration it ? it : thing.GetContainerOfType<Iteration>();
+            participant = null;
+
+            if (iteration != null 
+                   && this.Session.OpenIterations.TryGetValue(iteration, out var participation)
+                   && participation.Item1 != null
+                   && participation.Item2 != null)
             {
-                var participant = participation.Item2;
-                if (participant.Domain.Contains(ownedThing.Owner))
-                {
-                    return true;
-                }
+                participant = participation.Item2;
+                return true;
             }
 
-            // OwnedThing directly under EngineeringModel (CommonFileStore)
-            // give permission if any active domain in the model
-            
-            // get all activedomain for the current model
-            var currentModel = (EngineeringModel)thing.TopContainer;
-            return this.Session.OpenIterations.Where(x => x.Key.Container == currentModel).Select(x => x.Value).Any();
+            return false;
         }
     }
 }


### PR DESCRIPTION
- Bugfix
- Boyscouting null checks and direct output vars

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
- Refactoring of PermissionService.CanWriteIfParticipantOwned method. CommonFileStore implementation did not work OK (checked at TopContainer instead of Container property) and it is also moved to the top of the method.
All other cases now return False when needed.

- Boyscouting (null checks and out vars)

- Adding unit tests for Requirement and for a direct child of EngineeringModel (in this case CommonFileStore)
