### PR TITLE
Fix Folder.GetDerivedPath()

### DIFF
--- a/CDP4Common.NetCore.Tests/Poco/FileRevisionTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Poco/FileRevisionTestFixture.cs
@@ -2,7 +2,7 @@
 // <copyright file="FileRevisionTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -47,14 +47,20 @@ namespace CDP4Common.Tests.Poco
 
             this.filerev.FileType.Add(new FileType(Guid.NewGuid(), null, null) { Extension = "ext1" });
             this.filerev.FileType.Add(new FileType(Guid.NewGuid(), null, null) { Extension = "ext2" });
-
-            this.filerev.ContainingFolder = this.folder;
         }
 
         [Test]
-        public void VerifyPath()
+        public void VerifyPathForFileRevisionLocatedInFolder()
         {
+            this.filerev.ContainingFolder = this.folder;
             Assert.AreEqual("/path/filerev.ext1.ext2", this.filerev.Path);
+        }
+
+        [Test]
+        public void VerifyPathForFileRevisionLocatedInFileStore()
+        {
+            this.filerev.ContainingFolder = null;
+            Assert.AreEqual("filerev.ext1.ext2", this.filerev.Path);
         }
     }
 }

--- a/CDP4Common/CDP4Common.csproj
+++ b/CDP4Common/CDP4Common.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;netstandard1.6;netstandard2.0</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4Common Community Edition</Title>
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>6.0.1</VersionPrefix>
     <Description>CDP4 Common Class Library that contains DTOs, POCOs</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathaniel, Kamil</Authors>

--- a/CDP4Common/Poco/FileRevision.cs
+++ b/CDP4Common/Poco/FileRevision.cs
@@ -45,6 +45,8 @@ namespace CDP4Common.EngineeringModelData
             {
                 path.Append(containingFolder.Path);
                 path.Append("/");
+                path.Append(this.ContainingFolder.Name);
+                path.Append("/");
             }
 
             path.Append(this.Name);

--- a/CDP4Common/Poco/FileRevision.cs
+++ b/CDP4Common/Poco/FileRevision.cs
@@ -1,8 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FileRevision.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -40,14 +40,13 @@ namespace CDP4Common.EngineeringModelData
         {
             var path = new StringBuilder();
             var containingFolder = this.ContainingFolder;
+
             if (containingFolder != null)
             {
                 path.Append(containingFolder.Path);
                 path.Append("/");
             }
 
-            path.Append(this.ContainingFolder.Name);
-            path.Append("/");
             path.Append(this.Name);
 
             foreach (FileType fileType in this.FileType)

--- a/CDP4Common/Poco/FileRevision.cs
+++ b/CDP4Common/Poco/FileRevision.cs
@@ -36,14 +36,13 @@ namespace CDP4Common.EngineeringModelData
         /// Returns the derived <see cref="Path"/> value
         /// </summary>
         /// <returns>The <see cref="Path"/> value</returns>
-        protected string GetDerivedPath()
+        private string GetDerivedPath()
         {
             var path = new StringBuilder();
-            var containingFolder = this.ContainingFolder;
 
-            if (containingFolder != null)
+            if (this.ContainingFolder != null)
             {
-                path.Append(containingFolder.Path);
+                path.Append(this.ContainingFolder.Path);
                 path.Append("/");
                 path.Append(this.ContainingFolder.Name);
                 path.Append("/");


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix null reference in Folder.GetDerivedPath method