### PR TITLE
Do not add empty extensions to the calculated path

### DIFF
--- a/CDP4Common.Tests/Poco/FileRevisionTestFixture.cs
+++ b/CDP4Common.Tests/Poco/FileRevisionTestFixture.cs
@@ -1,9 +1,8 @@
-﻿#region Copyright
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FileRevisionTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -22,13 +21,14 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4Common.Tests.Poco
 {
     using System;
+
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -40,12 +40,14 @@ namespace CDP4Common.Tests.Poco
         [SetUp]
         public void Setup()
         {
-            this.folder = new Folder(Guid.NewGuid(), null, null) {Name = "path"};
+            this.folder = new Folder(Guid.NewGuid(), null, null) { Name = "path" };
 
             this.filerev = new FileRevision(Guid.NewGuid(), null, null);
             this.filerev.Name = "filerev";
 
             this.filerev.FileType.Add(new FileType(Guid.NewGuid(), null, null) { Extension = "ext1" });
+            this.filerev.FileType.Add(new FileType(Guid.NewGuid(), null, null) { Extension = null });
+            this.filerev.FileType.Add(new FileType(Guid.NewGuid(), null, null) { Extension = "" });
             this.filerev.FileType.Add(new FileType(Guid.NewGuid(), null, null) { Extension = "ext2" });
 
             this.filerev.ContainingFolder = this.folder;

--- a/CDP4Common/CDP4Common.csproj
+++ b/CDP4Common/CDP4Common.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;netstandard1.6;netstandard2.0</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4Common Community Edition</Title>
-    <VersionPrefix>6.1.0</VersionPrefix>
+    <VersionPrefix>6.1.1</VersionPrefix>
     <Description>CDP4 Common Class Library that contains DTOs, POCOs</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathaniel, Kamil</Authors>

--- a/CDP4Common/Poco/FileRevision.cs
+++ b/CDP4Common/Poco/FileRevision.cs
@@ -24,8 +24,8 @@
 
 namespace CDP4Common.EngineeringModelData
 {
+    using System.Linq;
     using System.Text;
-    using CDP4Common.SiteDirectoryData;
 
     /// <summary>
     /// Extended part for the auto-generated <see cref="FileRevision"/>
@@ -50,7 +50,7 @@ namespace CDP4Common.EngineeringModelData
 
             path.Append(this.Name);
 
-            foreach (FileType fileType in this.FileType)
+            foreach (var fileType in this.FileType.Where(x => !string.IsNullOrWhiteSpace(x.Extension)))
             {
                 path.Append(".");
                 path.Append(fileType.Extension);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
A FileType could have an empty extension.
In that case the extension and the including separator (dot) should not be added to the path property.