### PR TITLE
Fixes #136 Added ValueSetConverter.TryParseDouble

### DIFF
--- a/CDP4Common.NetCore.Tests/Helpers/ValueSetConverterTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Helpers/ValueSetConverterTestFixture.cs
@@ -1,0 +1,81 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ValueSetConverterTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Tests.Helpers
+{
+    using System.Globalization;
+
+    using CDP4Common.Helpers;
+    using CDP4Common.SiteDirectoryData;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tets for the <see cref="ValueSetConverter"/> class
+    /// </summary>
+    [TestFixture]
+    public class ValueSetConverterTestFixture
+    {
+        [SetUp]
+        public void SetUp()
+        {
+        }
+
+        [Test]
+        [TestCaseSource(nameof(TestCases))]
+        public void VerifyThatValuesAreCalculatedCorrectly(string valueArrayValue, double expectedValue1, double expectedValue2, bool expectedTryParseResult, ParameterType parameterType)
+        {
+            var culture = new CultureInfo("en-GB")
+            {
+                NumberFormat =
+                {
+                    NumberDecimalSeparator = ",",
+                    NumberGroupSeparator = "."
+                }
+            };
+
+            System.Threading.Thread.CurrentThread.CurrentCulture = culture;
+            Assert.AreEqual(expectedTryParseResult, ValueSetConverter.TryParseDouble(valueArrayValue, parameterType, out var calculatedValue1));
+            Assert.AreEqual(expectedValue1, calculatedValue1);
+
+            culture.NumberFormat.NumberDecimalSeparator = ".";
+            culture.NumberFormat.NumberGroupSeparator = ",";
+
+            Assert.AreEqual(expectedTryParseResult, ValueSetConverter.TryParseDouble(valueArrayValue, parameterType, out var calculatedValue2));
+            Assert.AreEqual(expectedValue2, calculatedValue2);
+        }
+
+        private static readonly object[] TestCases =
+        {
+            new object[] { "11", 11, 11, true, new SimpleQuantityKind()},
+            new object[] { "11.11", 11.11, 11.11, true, new SimpleQuantityKind()},
+            new object[] { "11.11", 0, 0, false, null},
+            new object[] { "11,11", 11.11, 1111, true, new SimpleQuantityKind()},
+            new object[] { "-", 0, 0, true, new SimpleQuantityKind()},
+            new object[] { "", 0, 0, true, new SimpleQuantityKind()},
+            new object[] { " ", 0, 0, true, new SimpleQuantityKind()},
+            new object[] { "aa", 0, 0, false, new SimpleQuantityKind() }
+        };
+    }
+}

--- a/CDP4Common.NetCore.Tests/Poco/OptionTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Poco/OptionTestFixture.cs
@@ -58,22 +58,33 @@ namespace CDP4Common.Tests.Poco
 
             var option = nestedElementTreeGeneratorTestFixture.iteration.Option.Single(x => x.ShortName == "OPT_A");
 
-            var doubleParameters = option.GetNestedParameterValuesByPath<double>("Sat\\m\\\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
+            var doubleParameters = option.GetNestedParameterValuesByPath<double>(@"Sat\m\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
             Assert.AreEqual(2, doubleParameters.Count);
             Assert.AreEqual(2D, doubleParameters.First());
             Assert.AreEqual(3D, doubleParameters.Last());
 
-            var stringParameters = option.GetNestedParameterValuesByPath<string>("Sat\\m\\\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
+            var stringParameters = option.GetNestedParameterValuesByPath<string>(@"Sat\m\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
             Assert.AreEqual(2, stringParameters.Count);
             Assert.AreEqual("2", stringParameters.First());
             Assert.AreEqual("3", stringParameters.Last());
 
-            Assert.Throws<FormatException>(() => option.GetNestedParameterValuesByPath<bool>("Sat\\m\\\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise));
+            Assert.Throws<FormatException>(() => option.GetNestedParameterValuesByPath<bool>(@"Sat\m\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise));
 
-            var objectParameters = option.GetNestedParameterValuesByPath<object>("Sat\\m\\\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
+            var objectParameters = option.GetNestedParameterValuesByPath<object>(@"Sat\m\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
             Assert.AreEqual(2, objectParameters.Count);
             Assert.AreEqual(2D, Convert.ChangeType(objectParameters.First(), typeof(double)));
             Assert.AreEqual("3", Convert.ChangeType(objectParameters.Last(), typeof(string)));
+
+            var domainCheckParameters = option.GetNestedParameterValuesByPath<double>(@"Sat.bat_b\v\1\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
+            Assert.AreEqual(0, domainCheckParameters.Count);
+
+            var domainCheckParametersWithCorrectDomain = option.GetNestedParameterValuesByPath<double>(@"Sat.bat_b\v\1\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise_2).ToList();
+            Assert.AreEqual(1, domainCheckParametersWithCorrectDomain.Count);
+            Assert.AreEqual(220D, domainCheckParametersWithCorrectDomain.First());
+
+            var domain2CheckParameters = option.GetNestedParameterValuesByPath<double>(@"Sat.bat_b\v\1\OPT_A").ToList();
+            Assert.AreEqual(1, domain2CheckParameters.Count);
+            Assert.AreEqual(220D, domain2CheckParameters.First());
         }
     }
 }

--- a/CDP4Common.Tests/Helpers/ValueSetConverterTestFixture.cs
+++ b/CDP4Common.Tests/Helpers/ValueSetConverterTestFixture.cs
@@ -1,0 +1,81 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ValueSetConverterTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Tests.Helpers
+{
+    using System.Globalization;
+
+    using CDP4Common.Helpers;
+    using CDP4Common.SiteDirectoryData;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tets for the <see cref="ValueSetConverter"/> class
+    /// </summary>
+    [TestFixture]
+    public class ValueSetConverterTestFixture
+    {
+        [SetUp]
+        public void SetUp()
+        {
+        }
+
+        [Test]
+        [TestCaseSource(nameof(TestCases))]
+        public void VerifyThatValuesAreCalculatedCorrectly(string valueArrayValue, double expectedValue1, double expectedValue2, bool expectedTryParseResult, ParameterType parameterType)
+        {
+            var culture = new CultureInfo("en-GB")
+            {
+                NumberFormat =
+                {
+                    NumberDecimalSeparator = ",",
+                    NumberGroupSeparator = "."
+                }
+            };
+
+            System.Threading.Thread.CurrentThread.CurrentCulture = culture;
+            Assert.AreEqual(expectedTryParseResult, ValueSetConverter.TryParseDouble(valueArrayValue, parameterType, out var calculatedValue1));
+            Assert.AreEqual(expectedValue1, calculatedValue1);
+
+            culture.NumberFormat.NumberDecimalSeparator = ".";
+            culture.NumberFormat.NumberGroupSeparator = ",";
+
+            Assert.AreEqual(expectedTryParseResult, ValueSetConverter.TryParseDouble(valueArrayValue, parameterType, out var calculatedValue2));
+            Assert.AreEqual(expectedValue2, calculatedValue2);
+        }
+
+        private static readonly object[] TestCases =
+        {
+            new object[] { "11", 11, 11, true, new SimpleQuantityKind()},
+            new object[] { "11.11", 11.11, 11.11, true, new SimpleQuantityKind()},
+            new object[] { "11.11", 0, 0, false, null},
+            new object[] { "11,11", 11.11, 1111, true, new SimpleQuantityKind()},
+            new object[] { "-", 0, 0, true, new SimpleQuantityKind()},
+            new object[] { "", 0, 0, true, new SimpleQuantityKind()},
+            new object[] { " ", 0, 0, true, new SimpleQuantityKind()},
+            new object[] { "aa", 0, 0, false, new SimpleQuantityKind() }
+        };
+    }
+}

--- a/CDP4Common.Tests/Poco/OptionTestFixture.cs
+++ b/CDP4Common.Tests/Poco/OptionTestFixture.cs
@@ -58,22 +58,33 @@ namespace CDP4Common.Tests.Poco
 
             var option = nestedElementTreeGeneratorTestFixture.iteration.Option.Single(x => x.ShortName == "OPT_A");
 
-            var doubleParameters = option.GetNestedParameterValuesByPath<double>("Sat\\m\\\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
+            var doubleParameters = option.GetNestedParameterValuesByPath<double>(@"Sat\m\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
             Assert.AreEqual(2, doubleParameters.Count);
             Assert.AreEqual(2D, doubleParameters.First());
             Assert.AreEqual(3D, doubleParameters.Last());
 
-            var stringParameters = option.GetNestedParameterValuesByPath<string>("Sat\\m\\\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
+            var stringParameters = option.GetNestedParameterValuesByPath<string>(@"Sat\m\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
             Assert.AreEqual(2, stringParameters.Count);
             Assert.AreEqual("2", stringParameters.First());
             Assert.AreEqual("3", stringParameters.Last());
 
-            Assert.Throws<FormatException>(() => option.GetNestedParameterValuesByPath<bool>("Sat\\m\\\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise));
+            Assert.Throws<FormatException>(() => option.GetNestedParameterValuesByPath<bool>(@"Sat\m\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise));
 
-            var objectParameters = option.GetNestedParameterValuesByPath<object>("Sat\\m\\\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
+            var objectParameters = option.GetNestedParameterValuesByPath<object>(@"Sat\m\\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
             Assert.AreEqual(2, objectParameters.Count);
             Assert.AreEqual(2D, Convert.ChangeType(objectParameters.First(), typeof(double)));
             Assert.AreEqual("3", Convert.ChangeType(objectParameters.Last(), typeof(string)));
+
+            var domainCheckParameters = option.GetNestedParameterValuesByPath<double>(@"Sat.bat_b\v\1\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise).ToList();
+            Assert.AreEqual(0, domainCheckParameters.Count);
+
+            var domainCheckParametersWithCorrectDomain = option.GetNestedParameterValuesByPath<double>(@"Sat.bat_b\v\1\OPT_A", nestedElementTreeGeneratorTestFixture.domainOfExpertise_2).ToList();
+            Assert.AreEqual(1, domainCheckParametersWithCorrectDomain.Count);
+            Assert.AreEqual(220D, domainCheckParametersWithCorrectDomain.First());
+
+            var domain2CheckParameters = option.GetNestedParameterValuesByPath<double>(@"Sat.bat_b\v\1\OPT_A").ToList();
+            Assert.AreEqual(1, domain2CheckParameters.Count);
+            Assert.AreEqual(220D, domain2CheckParameters.First());
         }
     }
 }

--- a/CDP4Common/Poco/Option.cs
+++ b/CDP4Common/Poco/Option.cs
@@ -64,8 +64,42 @@ namespace CDP4Common.EngineeringModelData
         {
             var allParameters = new NestedElementTreeGenerator().GetNestedParameters(this, domain);
 
+            return this.GetNestedParameterValuesByPath<T>(path, allParameters);
+        }
+
+        /// <summary>
+        /// Finds <see cref="NestedParameter"/>s by their <see cref="NestedParameter.Path"/>s in the <see cref="Option"/>'s <see cref="NestedParameter"/>
+        /// and returns its <see cref="NestedParameter.ActualValue"/> "converted" to the generic <typeparamref name="T" />'s.
+        /// </summary>
+        /// <typeparam name="T">The generic type to which the <see cref="NestedParameter.ActualValue"/> needs to be "converted".</typeparam>
+        /// <param name="path">The path to search for in all this <see cref="Option"/>'s <see cref="NestedParameter.Path"/> properties.</param>
+        /// <returns>A single <see cref="NestedParameter"/> if the path was found
+        /// and its <see cref="NestedParameter.ActualValue"/> could be converted to the requested generic <typeparamref name="T"></typeparamref>, otherwise null.
+        /// If Convert.ChangeType fails, an <see cref="Exception"/> is thrown: <see href="https://docs.microsoft.com/en-us/dotnet/api/system.convert.changetype"/>.
+        /// </returns>
+        public IEnumerable<T> GetNestedParameterValuesByPath<T>(string path)
+        {
+            var allParameters = new NestedElementTreeGenerator().GetNestedParameters(this);
+
+            return this.GetNestedParameterValuesByPath<T>(path, allParameters);
+        }
+
+        /// <summary>
+        /// Finds <see cref="NestedParameter"/>s by their <see cref="NestedParameter.Path"/>s in the <see cref="Option"/>'s <see cref="NestedParameter"/>
+        /// and returns its <see cref="NestedParameter.ActualValue"/> "converted" to the generic <typeparamref name="T" />'s.
+        /// </summary>
+        /// <typeparam name="T">The generic type to which the <see cref="NestedParameter.ActualValue"/> needs to be "converted".</typeparam>
+        /// <param name="path">The path to search for in all this <see cref="Option"/>'s <see cref="NestedParameter.Path"/> properties.</param>
+        /// <param name="allParameters">A <see cref="IEnumerable{NestedParameter}"/> that contains all available <see cref="NestedParameter"/>s where we can search the <paramref name="path"/> for.</param>
+        /// <returns>A single <see cref="NestedParameter"/> if the path was found
+        /// and its <see cref="NestedParameter.ActualValue"/> could be converted to the requested generic <typeparamref name="T"></typeparamref>, otherwise null.
+        /// If Convert.ChangeType fails, an <see cref="Exception"/> is thrown: <see href="https://docs.microsoft.com/en-us/dotnet/api/system.convert.changetype"/>.
+        /// </returns>
+        public IEnumerable<T> GetNestedParameterValuesByPath<T>(string path, IEnumerable<NestedParameter> allParameters)
+        {
             return allParameters.Where(x => x.Path.Equals(path))
-                .Select(x => (T)Convert.ChangeType(x.ActualValue.ToValueSetObject(x.AssociatedParameter.ParameterType), typeof(T))).ToArray();
+                .Select(x => (T)Convert.ChangeType(x.ActualValue.ToValueSetObject(x.AssociatedParameter.ParameterType), typeof(T)))
+                .ToArray();
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
ValueSetConverter.TryParseDouble tries to converts a string to a double using 10-25 rules.