### PR TITLE
Fixes #138; Extra IsMemberOfCategory overload that does not use the Cache

### DIFF
--- a/CDP4Common.NetCore.Tests/Poco/NestedElementTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Poco/NestedElementTestFixture.cs
@@ -61,13 +61,19 @@ namespace CDP4Common.Tests.Poco
         {
             this.cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
 
+            this.iteration = new Iteration(Guid.NewGuid(), this.cache, this.uri);
+            this.option = new Option(Guid.NewGuid(), this.cache, this.uri) { Container = this.iteration };
+
+            this.iteration.Option.Add(this.option);
+
             this.nestedElement = new NestedElement(Guid.NewGuid(), this.cache, this.uri);
-            this.rootElementDef = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef", ShortName = "Def" };
-            this.elementDef1 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef1", ShortName = "Def1" };
-            this.elementDef2 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef2", ShortName = "Def2" };
+            this.rootElementDef = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef", ShortName = "Def", Container = this.iteration };
+            this.elementDef1 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef1", ShortName = "Def1", Container = this.iteration };
+            this.elementDef2 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef2", ShortName = "Def2", Container = this.iteration };
             this.elementUsage1 = new ElementUsage(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementUsage", ShortName = "Use1", ElementDefinition = this.elementDef1 };
             this.elementUsage2 = new ElementUsage(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementUsage2", ShortName = "Use2", ElementDefinition = this.elementDef2 };
 
+            this.iteration.TopElement = this.rootElementDef;
             this.rootElementDef.ContainedElement.Add(this.elementUsage1);
             this.elementDef1.ContainedElement.Add(this.elementUsage2);
 
@@ -88,11 +94,16 @@ namespace CDP4Common.Tests.Poco
             var lazyCategory = new Lazy<Thing>(() => this.category);
             this.cache.TryAdd(new CacheKey(this.category.Iid, null), lazyCategory);
 
+            var iterationSetup = new IterationSetup(Guid.NewGuid(), this.cache, this.uri);
+            this.iteration.IterationSetup = iterationSetup;
 
-            this.iteration = new Iteration(Guid.NewGuid(), this.cache, this.uri) { TopElement = this.rootElementDef };
-            this.option = new Option(Guid.NewGuid(), this.cache, this.uri) { Container = this.iteration };
+            var engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), this.cache, this.uri);
+            engineeringModelSetup.IterationSetup.Add(iterationSetup);
 
-            this.iteration.Option.Add(this.option);
+            var modelReferenceLibrary = new ModelReferenceDataLibrary(Guid.NewGuid(), this.cache, this.uri);
+
+            modelReferenceLibrary.DefinedCategory.Add(this.category);
+            engineeringModelSetup.RequiredRdl.Add(modelReferenceLibrary);
         }
 
         [Test]

--- a/CDP4Common.Tests/Poco/NestedElementTestFixture.cs
+++ b/CDP4Common.Tests/Poco/NestedElementTestFixture.cs
@@ -61,13 +61,19 @@ namespace CDP4Common.Tests.Poco
         {
             this.cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
 
+            this.iteration = new Iteration(Guid.NewGuid(), this.cache, this.uri);
+            this.option = new Option(Guid.NewGuid(), this.cache, this.uri) { Container = this.iteration };
+
+            this.iteration.Option.Add(this.option);
+
             this.nestedElement = new NestedElement(Guid.NewGuid(), this.cache, this.uri);
-            this.rootElementDef = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef", ShortName = "Def" };
-            this.elementDef1 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef1", ShortName = "Def1" };
-            this.elementDef2 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef2", ShortName = "Def2" };
-            this.elementUsage1 = new ElementUsage(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementUsage", ShortName = "Use1", ElementDefinition = this.elementDef1};
+            this.rootElementDef = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef", ShortName = "Def", Container = this.iteration };
+            this.elementDef1 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef1", ShortName = "Def1", Container = this.iteration };
+            this.elementDef2 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementDef2", ShortName = "Def2", Container = this.iteration };
+            this.elementUsage1 = new ElementUsage(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementUsage", ShortName = "Use1", ElementDefinition = this.elementDef1 };
             this.elementUsage2 = new ElementUsage(Guid.NewGuid(), this.cache, this.uri) { Name = "ElementUsage2", ShortName = "Use2", ElementDefinition = this.elementDef2 };
 
+            this.iteration.TopElement = this.rootElementDef;
             this.rootElementDef.ContainedElement.Add(this.elementUsage1);
             this.elementDef1.ContainedElement.Add(this.elementUsage2);
 
@@ -88,11 +94,16 @@ namespace CDP4Common.Tests.Poco
             var lazyCategory = new Lazy<Thing>(() => this.category);
             this.cache.TryAdd(new CacheKey(this.category.Iid, null), lazyCategory);
 
+            var iterationSetup = new IterationSetup(Guid.NewGuid(), this.cache, this.uri);
+            this.iteration.IterationSetup = iterationSetup;
 
-            this.iteration = new Iteration(Guid.NewGuid(), this.cache, this.uri) {TopElement = this.rootElementDef};
-            this.option = new Option(Guid.NewGuid(), this.cache, this.uri) { Container = this.iteration };
+            var engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), this.cache, this.uri);
+            engineeringModelSetup.IterationSetup.Add(iterationSetup);
 
-            this.iteration.Option.Add(this.option);
+            var modelReferenceLibrary = new ModelReferenceDataLibrary(Guid.NewGuid(), this.cache, this.uri);
+
+            modelReferenceLibrary.DefinedCategory.Add(this.category);
+            engineeringModelSetup.RequiredRdl.Add(modelReferenceLibrary);
         }
 
         [Test]

--- a/CDP4Common/Extensions/CategorizableThingExtensions.cs
+++ b/CDP4Common/Extensions/CategorizableThingExtensions.cs
@@ -58,7 +58,7 @@ namespace CDP4Common.SiteDirectoryData
         public static bool IsMemberOfCategory(this ICategorizableThing categorizableThing, Category category)
         {
             var categoriesToCheck = category.AllDerivedCategories().ToList();
-            return IsMemberOfCategory_Impl(categorizableThing, category, categoriesToCheck);
+            return IsMemberOfCategoryImplementation(categorizableThing, category, categoriesToCheck);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace CDP4Common.SiteDirectoryData
             var categoriesinRequiredRdls = requiredRdls.SelectMany(x => x.DefinedCategory).ToList();
             var categoriesToCheck = category.AllDerivedCategories(categoriesinRequiredRdls).ToList();
 
-            return IsMemberOfCategory_Impl(categorizableThing, category, categoriesToCheck);
+            return IsMemberOfCategoryImplementation(categorizableThing, category, categoriesToCheck);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace CDP4Common.SiteDirectoryData
         /// sub <see cref="Category"/> instances. Returns false if the <see cref="ICategorizableThing"/> is not a member
         /// of the <paramref name="category"/> nor any of it's sub <see cref="Category"/> instances.
         /// </returns>
-        private static bool IsMemberOfCategory_Impl(this ICategorizableThing categorizableThing, Category category, IEnumerable<Category> allDerivedCategories)
+        private static bool IsMemberOfCategoryImplementation(this ICategorizableThing categorizableThing, Category category, IEnumerable<Category> allDerivedCategories)
         {
             var categoriesToCheck = allDerivedCategories.ToList();
             categoriesToCheck.Add(category);

--- a/CDP4Common/Extensions/CategorizableThingExtensions.cs
+++ b/CDP4Common/Extensions/CategorizableThingExtensions.cs
@@ -41,6 +41,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the <see cref="ICategorizableThing"/> and checks whether it is a member of the 
         /// supplied <see cref="Category"/>, this includes membership of the sub <see cref="Category"/> instances
         /// of the provided <see cref="Category"/>
+        /// Extensive usage of this overload can slow down performance significantly.
+        /// Please use the overload that takes an <see cref="IEnumerable{ReferenceDataLibrary}"/> as a parameter for better performance.
         /// </summary>
         /// <param name="categorizableThing">
         /// The <see cref="ICategorizableThing"/> instance that is being queried.
@@ -55,20 +57,65 @@ namespace CDP4Common.SiteDirectoryData
         /// </returns>
         public static bool IsMemberOfCategory(this ICategorizableThing categorizableThing, Category category)
         {
-            var memberOfCategories = categorizableThing.GetAllCategories();
-
             var categoriesToCheck = category.AllDerivedCategories().ToList();
+            return IsMemberOfCategory_Impl(categorizableThing, category, categoriesToCheck);
+        }
+
+        /// <summary>
+        /// Queries the <see cref="ICategorizableThing"/> and checks whether it is a member of the 
+        /// supplied <see cref="Category"/>, this includes membership of the sub <see cref="Category"/> instances
+        /// of the provided <see cref="Category"/>
+        /// </summary>
+        /// <param name="categorizableThing">
+        /// The <see cref="ICategorizableThing"/> instance that is being queried.
+        /// </param>
+        /// <param name="category">
+        /// The <see cref="Category"/> that the <see cref="ICategorizableThing"/> may be a member of.
+        /// </param>
+        /// <param name="requiredRdls">
+        /// An <see cref="IEnumerable{ReferenceDataLibrary}"/> that holds all <see cref="ReferenceDataLibrary"/>s
+        /// where derived <see cref="Category"/>s if <paramref name="category"/> can be found.
+        /// </param>
+        /// <returns>
+        /// returns true if the <see cref="ICategorizableThing"/> is a member of the <paramref name="category"/>, including it's 
+        /// sub <see cref="Category"/> instances. Returns false if the <see cref="ICategorizableThing"/> is not a member
+        /// of the <paramref name="category"/> nor any of it's sub <see cref="Category"/> instances.
+        /// </returns>
+        public static bool IsMemberOfCategory(this ICategorizableThing categorizableThing, Category category, IEnumerable<ReferenceDataLibrary> requiredRdls)
+        {
+            var categoriesinRequiredRdls = requiredRdls.SelectMany(x => x.DefinedCategory).ToList();
+            var categoriesToCheck = category.AllDerivedCategories(categoriesinRequiredRdls).ToList();
+
+            return IsMemberOfCategory_Impl(categorizableThing, category, categoriesToCheck);
+        }
+
+        /// <summary>
+        /// Queries the <see cref="ICategorizableThing"/> and checks whether it is a member of the 
+        /// supplied <see cref="Category"/>, this includes membership of the sub <see cref="Category"/> instances
+        /// of the provided <see cref="Category"/>
+        /// </summary>
+        /// <param name="categorizableThing">
+        /// The <see cref="ICategorizableThing"/> instance that is being queried.
+        /// </param>
+        /// <param name="category">
+        /// The <see cref="Category"/> that the <see cref="ICategorizableThing"/> may be a member of.
+        /// </param>
+        /// <param name="allDerivedCategories">
+        /// A <see cref="IEnumerable{Category}"/> that contains all <see cref="Category"/>s that are derived from <paramref name="category"/>.
+        /// </param>
+        /// <returns>
+        /// returns true if the <see cref="ICategorizableThing"/> is a member of the <paramref name="category"/>, including it's 
+        /// sub <see cref="Category"/> instances. Returns false if the <see cref="ICategorizableThing"/> is not a member
+        /// of the <paramref name="category"/> nor any of it's sub <see cref="Category"/> instances.
+        /// </returns>
+        private static bool IsMemberOfCategory_Impl(this ICategorizableThing categorizableThing, Category category, IEnumerable<Category> allDerivedCategories)
+        {
+            var categoriesToCheck = allDerivedCategories.ToList();
             categoriesToCheck.Add(category);
 
-            foreach (var memberOfCategory in memberOfCategories)
-            {
-                if (categoriesToCheck.Contains(memberOfCategory))
-                {
-                    return true;
-                }
-            }
+            var memberOfCategories = categorizableThing.GetAllCategories();
 
-            return false;
+            return memberOfCategories.Any(memberOfCategory => categoriesToCheck.Contains(memberOfCategory));
         }
 
         /// <summary>

--- a/CDP4Common/Poco/Category.cs
+++ b/CDP4Common/Poco/Category.cs
@@ -72,23 +72,10 @@ namespace CDP4Common.SiteDirectoryData
         /// </returns>
         public IEnumerable<Category> AllDerivedCategories()
         {
-            //var currentDateTime = DateTime.Now;
-            //List<Category> categories = null;
-
-            //if (this.categoryCache == null || currentDateTime - this.lastCacheRequest > new TimeSpan(0, 0, 0, 1))
-            //{
             var categories = this.Cache.Select(x => x.Value)
                 .Where(lazy => lazy.Value.ClassKind == ClassKind.Category)
                 .Select(lazy => lazy.Value)
                 .Cast<Category>().ToList();
-
-                //this.categoryCache = categories;
-                //this.lastCacheRequest = currentDateTime;
-            //}
-            //else
-            //{
-            //    categories = this.categoryCache;
-            //}
 
             foreach (var category in categories)
             {

--- a/CDP4Common/Poco/Category.cs
+++ b/CDP4Common/Poco/Category.cs
@@ -59,6 +59,10 @@ namespace CDP4Common.SiteDirectoryData
             return supercategories;
         }
 
+        private List<Category> categoryCache = null;
+
+        private DateTime lastCacheRequest = DateTime.MinValue;
+
         /// <summary>
         /// Queries the full hierarchy of categories that are derived categories of the current <see cref="Category"/>
         /// and returns those as an <see cref="IEnumerable{Category}"/>
@@ -68,10 +72,23 @@ namespace CDP4Common.SiteDirectoryData
         /// </returns>
         public IEnumerable<Category> AllDerivedCategories()
         {
+            //var currentDateTime = DateTime.Now;
+            //List<Category> categories = null;
+
+            //if (this.categoryCache == null || currentDateTime - this.lastCacheRequest > new TimeSpan(0, 0, 0, 1))
+            //{
             var categories = this.Cache.Select(x => x.Value)
-                    .Where(lazy => lazy.Value.ClassKind == ClassKind.Category)
-                    .Select(lazy => lazy.Value)
-                    .Cast<Category>().ToList();
+                .Where(lazy => lazy.Value.ClassKind == ClassKind.Category)
+                .Select(lazy => lazy.Value)
+                .Cast<Category>().ToList();
+
+                //this.categoryCache = categories;
+                //this.lastCacheRequest = currentDateTime;
+            //}
+            //else
+            //{
+            //    categories = this.categoryCache;
+            //}
 
             foreach (var category in categories)
             {
@@ -97,7 +114,7 @@ namespace CDP4Common.SiteDirectoryData
         /// <returns>
         /// an <see cref="IEnumerable{Category}"/> that contains the <see cref="Category"/> instances that are derived from the current <see cref="Category"/>
         /// </returns>
-        private IEnumerable<Category> AllDerivedCategories(List<Category> categories)
+        public IEnumerable<Category> AllDerivedCategories(List<Category> categories)
         {
             foreach (var category in categories.Where(category => category.SuperCategory.Contains(this)))
             {

--- a/CDP4Common/Poco/ElementDefinition.cs
+++ b/CDP4Common/Poco/ElementDefinition.cs
@@ -221,18 +221,5 @@ namespace CDP4Common.EngineeringModelData
                 }
             }
         }
-
-        /// <summary>
-        /// Gets an <see cref="IEnumerable{ReferenceDataLibrary}"/> that contains the 
-        /// required <see cref="ReferenceDataLibrary"/> for the current <see cref="Thing"/>
-        /// </summary>
-        public override IEnumerable<ReferenceDataLibrary> RequiredRdls
-        {
-            get
-            {
-                var iteration = this.Container as Iteration;
-                return iteration?.RequiredRdls;
-            }
-        }
     }
 }

--- a/CDP4Common/Poco/ElementDefinition.cs
+++ b/CDP4Common/Poco/ElementDefinition.cs
@@ -28,7 +28,9 @@ namespace CDP4Common.EngineeringModelData
     using System.Collections.Generic;
     using System.Linq;
 
+    using CDP4Common.CommonData;
     using CDP4Common.Exceptions;
+    using CDP4Common.SiteDirectoryData;
 
     /// <summary>
     /// Extension for the <see cref="ElementDefinition"/> class
@@ -217,6 +219,19 @@ namespace CDP4Common.EngineeringModelData
                 {
                     parameter.ToBePublished = value;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets an <see cref="IEnumerable{ReferenceDataLibrary}"/> that contains the 
+        /// required <see cref="ReferenceDataLibrary"/> for the current <see cref="Thing"/>
+        /// </summary>
+        public override IEnumerable<ReferenceDataLibrary> RequiredRdls
+        {
+            get
+            {
+                var iteration = this.Container as Iteration;
+                return iteration?.RequiredRdls;
             }
         }
     }

--- a/CDP4Common/Poco/ElementUsage.cs
+++ b/CDP4Common/Poco/ElementUsage.cs
@@ -100,18 +100,5 @@ namespace CDP4Common.EngineeringModelData
                 }
             }
         }
-
-        /// <summary>
-        /// Gets an <see cref="IEnumerable{T}"/> that contains the 
-        /// required <see cref="ReferenceDataLibrary"/> for the current <see cref="Thing"/>
-        /// </summary>
-        public override IEnumerable<ReferenceDataLibrary> RequiredRdls
-        {
-            get
-            {
-                var elementDefinition = this.Container as ElementDefinition;
-                return elementDefinition?.RequiredRdls;
-            }
-        }
     }
 }

--- a/CDP4Common/Poco/ElementUsage.cs
+++ b/CDP4Common/Poco/ElementUsage.cs
@@ -25,9 +25,12 @@
 namespace CDP4Common.EngineeringModelData
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
 
+    using CDP4Common.CommonData;
     using CDP4Common.Exceptions;
+    using CDP4Common.SiteDirectoryData;
 
     /// <summary>
     /// Extension for the <see cref="ElementUsage"/> class
@@ -95,6 +98,19 @@ namespace CDP4Common.EngineeringModelData
                 {
                     parameterOverride.ToBePublished = value;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets an <see cref="IEnumerable{T}"/> that contains the 
+        /// required <see cref="ReferenceDataLibrary"/> for the current <see cref="Thing"/>
+        /// </summary>
+        public override IEnumerable<ReferenceDataLibrary> RequiredRdls
+        {
+            get
+            {
+                var elementDefinition = this.Container as ElementDefinition;
+                return elementDefinition?.RequiredRdls;
             }
         }
     }

--- a/CDP4Common/Poco/NestedElement.cs
+++ b/CDP4Common/Poco/NestedElement.cs
@@ -121,9 +121,22 @@ namespace CDP4Common.EngineeringModelData
         /// <returns>
         /// True if the <see cref="NestedElement"/> is  a member of the <paramref name="category"/>, otherwise false.
         /// </returns>
-        public bool IsMemberOfCategory(Category category) =>
-            (this.GetElementDefinition()?.IsMemberOfCategory(category) ?? false)
-            || (this.GetElementUsage()?.IsMemberOfCategory(category) ?? false);
+        public bool IsMemberOfCategory(Category category)
+        {
+            var elementBase = this.GetElementBase();
+
+            if (elementBase is ElementUsage elementUsage)
+            {
+                return elementUsage.IsMemberOfCategory(category, elementUsage.RequiredRdls);
+            }
+
+            if (elementBase is ElementDefinition elementDefinition)
+            {
+                return elementDefinition.IsMemberOfCategory(category, elementDefinition.RequiredRdls);
+            }
+
+            return false;
+        }
 
         /// <summary>
         /// Get the children of a <see cref="NestedElement"/>.

--- a/CDP4Common/Poco/NestedElement.cs
+++ b/CDP4Common/Poco/NestedElement.cs
@@ -125,17 +125,15 @@ namespace CDP4Common.EngineeringModelData
         {
             var elementBase = this.GetElementBase();
 
+            var elementDefinition = this.GetElementDefinition();
+            var iteration = elementDefinition.Container as Iteration;
+
             if (elementBase is ElementUsage elementUsage)
             {
-                return elementUsage.IsMemberOfCategory(category, elementUsage.RequiredRdls);
+                return elementUsage.IsMemberOfCategory(category, iteration?.RequiredRdls);
             }
 
-            if (elementBase is ElementDefinition elementDefinition)
-            {
-                return elementDefinition.IsMemberOfCategory(category, elementDefinition.RequiredRdls);
-            }
-
-            return false;
+            return elementDefinition.IsMemberOfCategory(category, iteration?.RequiredRdls);
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Extra overload that doesn't use the Cache and is therefore faster.