### PR TITLE
[Add] QueryReferencedThings() and QueryReferencedThingsDeep() methods to the abstract Thing class

### DIFF
--- a/CDP4Common.NetCore.Tests/Poco/ElementDefinitionTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Poco/ElementDefinitionTestFixture.cs
@@ -232,5 +232,26 @@ namespace CDP4Common.Tests.Poco
 
             Assert.Throws<ContainmentException>(() => def1.ReferencingElementUsages());
         }
+
+        [Test]
+        public void Verify_that_QueryReferencedThings_and_QueryReferencedThingsDeep()
+        {
+            var elementDefinition = new ElementDefinition(Guid.NewGuid(), null, null);
+            var superCategory = new Category(Guid.NewGuid(), null, null);
+            var category = new Category(Guid.NewGuid(), null, null);
+            category.SuperCategory.Add(superCategory);
+
+            elementDefinition.Category.Add(category);
+
+            var referencedThings = elementDefinition.QueryReferencedThings();
+
+            CollectionAssert.Contains(referencedThings, category);
+            CollectionAssert.DoesNotContain(referencedThings, superCategory);
+
+            var referencedThingsDeep = elementDefinition.QueryReferencedThingsDeep();
+
+            CollectionAssert.Contains(referencedThingsDeep, category);
+            CollectionAssert.Contains(referencedThingsDeep, superCategory);
+        }
     }
 }

--- a/CDP4Common.Tests/Poco/ElementDefinitionTestFixture.cs
+++ b/CDP4Common.Tests/Poco/ElementDefinitionTestFixture.cs
@@ -232,5 +232,26 @@ namespace CDP4Common.Tests.Poco
 
             Assert.Throws<ContainmentException>(() => def1.ReferencingElementUsages());
         }
+
+        [Test]
+        public void Verify_that_QueryReferencedThings_and_QueryReferencedThingsDeep()
+        {
+            var elementDefinition = new ElementDefinition(Guid.NewGuid(), null, null);
+            var superCategory = new Category(Guid.NewGuid(), null, null);
+            var category = new Category(Guid.NewGuid(), null, null);
+            category.SuperCategory.Add(superCategory);
+
+            elementDefinition.Category.Add(category);
+
+            var referencedThings = elementDefinition.QueryReferencedThings();
+
+            CollectionAssert.Contains(referencedThings, category);
+            CollectionAssert.DoesNotContain(referencedThings, superCategory);
+
+            var referencedThingsDeep = elementDefinition.QueryReferencedThingsDeep();
+
+            CollectionAssert.Contains(referencedThingsDeep, category);
+            CollectionAssert.Contains(referencedThingsDeep, superCategory);
+        }
     }
 }

--- a/CDP4Common/AutoGenPoco/ActionItem.cs
+++ b/CDP4Common/AutoGenPoco/ActionItem.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ActionItem.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -119,6 +119,26 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public DateTime DueDate { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ActionItem"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Actionee;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ActionItem"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ActionItem.cs
+++ b/CDP4Common/AutoGenPoco/ActionItem.cs
@@ -124,8 +124,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ActionItem"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ActualFiniteState.cs
+++ b/CDP4Common/AutoGenPoco/ActualFiniteState.cs
@@ -158,8 +158,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ActualFiniteState"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ActualFiniteState.cs
+++ b/CDP4Common/AutoGenPoco/ActualFiniteState.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ActualFiniteState.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -152,6 +152,29 @@ namespace CDP4Common.EngineeringModelData
         {
             get { return this.GetDerivedShortName(); }
             set { throw new InvalidOperationException("Forbidden Set value for the derived property ActualFiniteState.ShortName"); }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ActualFiniteState"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.PossibleState)
+            {
+                yield return thing;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ActualFiniteStateKind.cs
+++ b/CDP4Common/AutoGenPoco/ActualFiniteStateKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ActualFiniteStateKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ActualFiniteStateList.cs
+++ b/CDP4Common/AutoGenPoco/ActualFiniteStateList.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ActualFiniteStateList.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -172,6 +172,36 @@ namespace CDP4Common.EngineeringModelData
                 var containers = new List<IEnumerable>(base.ContainerLists);
                 containers.Add(this.ActualState);
                 return containers;
+            }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ActualFiniteStateList"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.ExcludeOption)
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
+
+            foreach (var thing in this.PossibleFiniteStateList.Select(x => x))
+            {
+                yield return thing;
             }
         }
 

--- a/CDP4Common/AutoGenPoco/ActualFiniteStateList.cs
+++ b/CDP4Common/AutoGenPoco/ActualFiniteStateList.cs
@@ -179,8 +179,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ActualFiniteStateList"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Alias.cs
+++ b/CDP4Common/AutoGenPoco/Alias.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Alias.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/AndExpression.cs
+++ b/CDP4Common/AutoGenPoco/AndExpression.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AndExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -94,6 +94,29 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<BooleanExpression> Term { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="AndExpression"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Term)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="AndExpression"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/AndExpression.cs
+++ b/CDP4Common/AutoGenPoco/AndExpression.cs
@@ -99,8 +99,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="AndExpression"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/AnnotationApprovalKind.cs
+++ b/CDP4Common/AutoGenPoco/AnnotationApprovalKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AnnotationApprovalKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/AnnotationClassificationKind.cs
+++ b/CDP4Common/AutoGenPoco/AnnotationClassificationKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AnnotationClassificationKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/AnnotationStatusKind.cs
+++ b/CDP4Common/AutoGenPoco/AnnotationStatusKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AnnotationStatusKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Approval.cs
+++ b/CDP4Common/AutoGenPoco/Approval.cs
@@ -116,8 +116,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Approval"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Approval.cs
+++ b/CDP4Common/AutoGenPoco/Approval.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Approval.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -111,6 +111,28 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public DomainOfExpertise Owner { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Approval"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Author;
+
+            yield return this.Owner;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="Approval"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ArrayParameterType.cs
+++ b/CDP4Common/AutoGenPoco/ArrayParameterType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ArrayParameterType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/BinaryNote.cs
+++ b/CDP4Common/AutoGenPoco/BinaryNote.cs
@@ -106,8 +106,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="BinaryNote"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/BinaryNote.cs
+++ b/CDP4Common/AutoGenPoco/BinaryNote.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BinaryNote.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -101,6 +101,26 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public FileType FileType { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="BinaryNote"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.FileType;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="BinaryNote"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/BinaryRelationship.cs
+++ b/CDP4Common/AutoGenPoco/BinaryRelationship.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BinaryRelationship.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -101,6 +101,28 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public Thing Target { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="BinaryRelationship"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Source;
+
+            yield return this.Target;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="BinaryRelationship"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/BinaryRelationship.cs
+++ b/CDP4Common/AutoGenPoco/BinaryRelationship.cs
@@ -106,8 +106,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="BinaryRelationship"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/BinaryRelationshipRule.cs
+++ b/CDP4Common/AutoGenPoco/BinaryRelationshipRule.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BinaryRelationshipRule.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -131,6 +131,30 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public Category TargetCategory { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="BinaryRelationshipRule"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.RelationshipCategory;
+
+            yield return this.SourceCategory;
+
+            yield return this.TargetCategory;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="BinaryRelationshipRule"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/BinaryRelationshipRule.cs
+++ b/CDP4Common/AutoGenPoco/BinaryRelationshipRule.cs
@@ -136,8 +136,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="BinaryRelationshipRule"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Book.cs
+++ b/CDP4Common/AutoGenPoco/Book.cs
@@ -166,8 +166,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Book"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Book.cs
+++ b/CDP4Common/AutoGenPoco/Book.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Book.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -160,6 +160,31 @@ namespace CDP4Common.ReportingData
                 containers.Add(this.Section);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Book"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/BooleanExpression.cs
+++ b/CDP4Common/AutoGenPoco/BooleanExpression.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BooleanExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/BooleanOperatorKind.cs
+++ b/CDP4Common/AutoGenPoco/BooleanOperatorKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BooleanOperatorKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/BooleanParameterType.cs
+++ b/CDP4Common/AutoGenPoco/BooleanParameterType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BooleanParameterType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Bounds.cs
+++ b/CDP4Common/AutoGenPoco/Bounds.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Bounds.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/BuiltInRuleVerification.cs
+++ b/CDP4Common/AutoGenPoco/BuiltInRuleVerification.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BuiltInRuleVerification.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Category.cs
+++ b/CDP4Common/AutoGenPoco/Category.cs
@@ -143,8 +143,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Category"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Category.cs
+++ b/CDP4Common/AutoGenPoco/Category.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Category.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -138,6 +138,29 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<Category> SuperCategory { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Category"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.SuperCategory)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="Category"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ChangeProposal.cs
+++ b/CDP4Common/AutoGenPoco/ChangeProposal.cs
@@ -97,8 +97,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ChangeProposal"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ChangeProposal.cs
+++ b/CDP4Common/AutoGenPoco/ChangeProposal.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ChangeProposal.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -92,6 +92,26 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public ChangeRequest ChangeRequest { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ChangeProposal"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ChangeRequest;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ChangeProposal"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ChangeRequest.cs
+++ b/CDP4Common/AutoGenPoco/ChangeRequest.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ChangeRequest.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Citation.cs
+++ b/CDP4Common/AutoGenPoco/Citation.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Citation.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -133,6 +133,26 @@ namespace CDP4Common.CommonData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public ReferenceSource Source { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Citation"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Source;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="Citation"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/Citation.cs
+++ b/CDP4Common/AutoGenPoco/Citation.cs
@@ -138,8 +138,8 @@ namespace CDP4Common.CommonData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Citation"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ClassKind.cs
+++ b/CDP4Common/AutoGenPoco/ClassKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ClassKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Color.cs
+++ b/CDP4Common/AutoGenPoco/Color.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Color.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/CommonFileStore.cs
+++ b/CDP4Common/AutoGenPoco/CommonFileStore.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CommonFileStore.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/CompoundParameterType.cs
+++ b/CDP4Common/AutoGenPoco/CompoundParameterType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CompoundParameterType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Constant.cs
+++ b/CDP4Common/AutoGenPoco/Constant.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Constant.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -132,6 +132,33 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: true, isNullable: false, isPersistent: true)]
         public ValueArray<string> Value { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Constant"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.ParameterType;
+
+            yield return this.Scale;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="Constant"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/Constant.cs
+++ b/CDP4Common/AutoGenPoco/Constant.cs
@@ -137,8 +137,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Constant"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ContractChangeNotice.cs
+++ b/CDP4Common/AutoGenPoco/ContractChangeNotice.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ContractChangeNotice.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -92,6 +92,26 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public ChangeProposal ChangeProposal { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ContractChangeNotice"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ChangeProposal;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ContractChangeNotice"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ContractChangeNotice.cs
+++ b/CDP4Common/AutoGenPoco/ContractChangeNotice.cs
@@ -97,8 +97,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ContractChangeNotice"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ContractDeviation.cs
+++ b/CDP4Common/AutoGenPoco/ContractDeviation.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ContractDeviation.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ConversionBasedUnit.cs
+++ b/CDP4Common/AutoGenPoco/ConversionBasedUnit.cs
@@ -105,8 +105,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ConversionBasedUnit"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ConversionBasedUnit.cs
+++ b/CDP4Common/AutoGenPoco/ConversionBasedUnit.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ConversionBasedUnit.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -100,6 +100,26 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public virtual MeasurementUnit ReferenceUnit { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ConversionBasedUnit"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ReferenceUnit;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ConversionBasedUnit"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/CyclicRatioScale.cs
+++ b/CDP4Common/AutoGenPoco/CyclicRatioScale.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CyclicRatioScale.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DateParameterType.cs
+++ b/CDP4Common/AutoGenPoco/DateParameterType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DateParameterType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DateTimeParameterType.cs
+++ b/CDP4Common/AutoGenPoco/DateTimeParameterType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeParameterType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DecompositionRule.cs
+++ b/CDP4Common/AutoGenPoco/DecompositionRule.cs
@@ -130,8 +130,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DecompositionRule"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/DecompositionRule.cs
+++ b/CDP4Common/AutoGenPoco/DecompositionRule.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DecompositionRule.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -125,6 +125,31 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public int MinContained { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DecompositionRule"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.ContainedCategory)
+            {
+                yield return thing;
+            }
+
+            yield return this.ContainingCategory;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="DecompositionRule"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/DefinedThing.cs
+++ b/CDP4Common/AutoGenPoco/DefinedThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DefinedThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Definition.cs
+++ b/CDP4Common/AutoGenPoco/Definition.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Definition.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DerivedQuantityKind.cs
+++ b/CDP4Common/AutoGenPoco/DerivedQuantityKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DerivedQuantityKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DerivedUnit.cs
+++ b/CDP4Common/AutoGenPoco/DerivedUnit.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DerivedUnit.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DiagramCanvas.cs
+++ b/CDP4Common/AutoGenPoco/DiagramCanvas.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramCanvas.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DiagramEdge.cs
+++ b/CDP4Common/AutoGenPoco/DiagramEdge.cs
@@ -131,8 +131,8 @@ namespace CDP4Common.DiagramData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DiagramEdge"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/DiagramEdge.cs
+++ b/CDP4Common/AutoGenPoco/DiagramEdge.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramEdge.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -125,6 +125,28 @@ namespace CDP4Common.DiagramData
                 containers.Add(this.Point);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DiagramEdge"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Source;
+
+            yield return this.Target;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/DiagramElementContainer.cs
+++ b/CDP4Common/AutoGenPoco/DiagramElementContainer.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramElementContainer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DiagramElementThing.cs
+++ b/CDP4Common/AutoGenPoco/DiagramElementThing.cs
@@ -131,8 +131,8 @@ namespace CDP4Common.DiagramData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DiagramElementThing"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/DiagramElementThing.cs
+++ b/CDP4Common/AutoGenPoco/DiagramElementThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramElementThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -125,6 +125,28 @@ namespace CDP4Common.DiagramData
                 containers.Add(this.LocalStyle);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DiagramElementThing"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.DepictedThing;
+
+            yield return this.SharedStyle;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/DiagramObject.cs
+++ b/CDP4Common/AutoGenPoco/DiagramObject.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramObject.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DiagramShape.cs
+++ b/CDP4Common/AutoGenPoco/DiagramShape.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramShape.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DiagramThingBase.cs
+++ b/CDP4Common/AutoGenPoco/DiagramThingBase.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramThingBase.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DiagrammingStyle.cs
+++ b/CDP4Common/AutoGenPoco/DiagrammingStyle.cs
@@ -230,8 +230,8 @@ namespace CDP4Common.DiagramData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DiagrammingStyle"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/DiagrammingStyle.cs
+++ b/CDP4Common/AutoGenPoco/DiagrammingStyle.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagrammingStyle.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -224,6 +224,30 @@ namespace CDP4Common.DiagramData
                 containers.Add(this.UsedColor);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DiagrammingStyle"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.FillColor;
+
+            yield return this.FontColor;
+
+            yield return this.StrokeColor;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/DiscussionItem.cs
+++ b/CDP4Common/AutoGenPoco/DiscussionItem.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiscussionItem.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -91,6 +91,26 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public virtual DiscussionItem ReplyTo { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DiscussionItem"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ReplyTo;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="DiscussionItem"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/DiscussionItem.cs
+++ b/CDP4Common/AutoGenPoco/DiscussionItem.cs
@@ -96,8 +96,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DiscussionItem"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/DomainFileStore.cs
+++ b/CDP4Common/AutoGenPoco/DomainFileStore.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainFileStore.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/DomainOfExpertise.cs
+++ b/CDP4Common/AutoGenPoco/DomainOfExpertise.cs
@@ -109,8 +109,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DomainOfExpertise"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/DomainOfExpertise.cs
+++ b/CDP4Common/AutoGenPoco/DomainOfExpertise.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainOfExpertise.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -104,6 +104,29 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public bool IsDeprecated { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DomainOfExpertise"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="DomainOfExpertise"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/DomainOfExpertiseGroup.cs
+++ b/CDP4Common/AutoGenPoco/DomainOfExpertiseGroup.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainOfExpertiseGroup.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -103,6 +103,29 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public bool IsDeprecated { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DomainOfExpertiseGroup"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Domain)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="DomainOfExpertiseGroup"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/DomainOfExpertiseGroup.cs
+++ b/CDP4Common/AutoGenPoco/DomainOfExpertiseGroup.cs
@@ -108,8 +108,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="DomainOfExpertiseGroup"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ElementBase.cs
+++ b/CDP4Common/AutoGenPoco/ElementBase.cs
@@ -107,8 +107,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ElementBase"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ElementBase.cs
+++ b/CDP4Common/AutoGenPoco/ElementBase.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ElementBase.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -102,6 +102,31 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public virtual DomainOfExpertise Owner { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ElementBase"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ElementBase"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ElementDefinition.cs
+++ b/CDP4Common/AutoGenPoco/ElementDefinition.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ElementDefinition.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -151,6 +151,29 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.Parameter);
                 containers.Add(this.ParameterGroup);
                 return containers;
+            }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ElementDefinition"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.ReferencedElement)
+            {
+                yield return thing;
             }
         }
 

--- a/CDP4Common/AutoGenPoco/ElementDefinition.cs
+++ b/CDP4Common/AutoGenPoco/ElementDefinition.cs
@@ -158,8 +158,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ElementDefinition"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ElementUsage.cs
+++ b/CDP4Common/AutoGenPoco/ElementUsage.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ElementUsage.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -148,6 +148,31 @@ namespace CDP4Common.EngineeringModelData
                 var containers = new List<IEnumerable>(base.ContainerLists);
                 containers.Add(this.ParameterOverride);
                 return containers;
+            }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ElementUsage"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ElementDefinition;
+
+            foreach (var thing in this.ExcludeOption)
+            {
+                yield return thing;
             }
         }
 

--- a/CDP4Common/AutoGenPoco/ElementUsage.cs
+++ b/CDP4Common/AutoGenPoco/ElementUsage.cs
@@ -155,8 +155,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ElementUsage"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/EmailAddress.cs
+++ b/CDP4Common/AutoGenPoco/EmailAddress.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EmailAddress.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/EngineeringModel.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModel.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModel.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -182,6 +182,26 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.ModellingAnnotation);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="EngineeringModel"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.EngineeringModelSetup;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/EngineeringModel.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModel.cs
@@ -188,8 +188,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="EngineeringModel"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/EngineeringModelDataAnnotation.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModelDataAnnotation.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelDataAnnotation.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -135,6 +135,28 @@ namespace CDP4Common.ReportingData
                 containers.Add(this.RelatedThing);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="EngineeringModelDataAnnotation"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Author;
+
+            yield return this.PrimaryAnnotatedThing;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/EngineeringModelDataAnnotation.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModelDataAnnotation.cs
@@ -141,8 +141,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="EngineeringModelDataAnnotation"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/EngineeringModelDataDiscussionItem.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModelDataDiscussionItem.cs
@@ -97,8 +97,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="EngineeringModelDataDiscussionItem"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/EngineeringModelDataDiscussionItem.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModelDataDiscussionItem.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelDataDiscussionItem.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -92,6 +92,26 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public Participant Author { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="EngineeringModelDataDiscussionItem"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Author;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="EngineeringModelDataDiscussionItem"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/EngineeringModelDataNote.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModelDataNote.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelDataNote.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/EngineeringModelKind.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModelKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/EngineeringModelSetup.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModelSetup.cs
@@ -194,8 +194,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="EngineeringModelSetup"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/EngineeringModelSetup.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModelSetup.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelSetup.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -187,6 +187,29 @@ namespace CDP4Common.SiteDirectoryData
                 containers.Add(this.Participant);
                 containers.Add(this.RequiredRdl);
                 return containers;
+            }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="EngineeringModelSetup"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.ActiveDomain)
+            {
+                yield return thing;
             }
         }
 

--- a/CDP4Common/AutoGenPoco/EnumerationParameterType.cs
+++ b/CDP4Common/AutoGenPoco/EnumerationParameterType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EnumerationParameterType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/EnumerationValueDefinition.cs
+++ b/CDP4Common/AutoGenPoco/EnumerationValueDefinition.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EnumerationValueDefinition.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ExclusiveOrExpression.cs
+++ b/CDP4Common/AutoGenPoco/ExclusiveOrExpression.cs
@@ -99,8 +99,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ExclusiveOrExpression"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ExclusiveOrExpression.cs
+++ b/CDP4Common/AutoGenPoco/ExclusiveOrExpression.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ExclusiveOrExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -94,6 +94,29 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<BooleanExpression> Term { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ExclusiveOrExpression"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Term)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ExclusiveOrExpression"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ExternalIdentifierMap.cs
+++ b/CDP4Common/AutoGenPoco/ExternalIdentifierMap.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ExternalIdentifierMap.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -162,6 +162,28 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.Correspondence);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ExternalFormat;
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ExternalIdentifierMap.cs
+++ b/CDP4Common/AutoGenPoco/ExternalIdentifierMap.cs
@@ -168,8 +168,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ExternalIdentifierMap"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/File.cs
+++ b/CDP4Common/AutoGenPoco/File.cs
@@ -142,8 +142,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="File"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/File.cs
+++ b/CDP4Common/AutoGenPoco/File.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="File.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -136,6 +136,33 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.FileRevision);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="File"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.LockedBy;
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/FileRevision.cs
+++ b/CDP4Common/AutoGenPoco/FileRevision.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FileRevision.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -161,6 +161,33 @@ namespace CDP4Common.EngineeringModelData
         {
             get { return this.GetDerivedPath(); }
             set { throw new InvalidOperationException("Forbidden Set value for the derived property FileRevision.Path"); }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="FileRevision"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ContainingFolder;
+
+            yield return this.Creator;
+
+            foreach (var thing in this.FileType.Select(x => x))
+            {
+                yield return thing;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/FileRevision.cs
+++ b/CDP4Common/AutoGenPoco/FileRevision.cs
@@ -167,8 +167,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="FileRevision"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/FileStore.cs
+++ b/CDP4Common/AutoGenPoco/FileStore.cs
@@ -152,8 +152,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="FileStore"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/FileStore.cs
+++ b/CDP4Common/AutoGenPoco/FileStore.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FileStore.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -146,6 +146,26 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.Folder);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="FileStore"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/FileType.cs
+++ b/CDP4Common/AutoGenPoco/FileType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FileType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -116,6 +116,29 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public bool IsDeprecated { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="FileType"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="FileType"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/FileType.cs
+++ b/CDP4Common/AutoGenPoco/FileType.cs
@@ -121,8 +121,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="FileType"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Folder.cs
+++ b/CDP4Common/AutoGenPoco/Folder.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Folder.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -148,6 +148,30 @@ namespace CDP4Common.EngineeringModelData
         {
             get { return this.GetDerivedPath(); }
             set { throw new InvalidOperationException("Forbidden Set value for the derived property Folder.Path"); }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Folder"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ContainingFolder;
+
+            yield return this.Creator;
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Folder.cs
+++ b/CDP4Common/AutoGenPoco/Folder.cs
@@ -154,8 +154,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Folder"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/GenericAnnotation.cs
+++ b/CDP4Common/AutoGenPoco/GenericAnnotation.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="GenericAnnotation.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Glossary.cs
+++ b/CDP4Common/AutoGenPoco/Glossary.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Glossary.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -124,6 +124,29 @@ namespace CDP4Common.SiteDirectoryData
                 var containers = new List<IEnumerable>(base.ContainerLists);
                 containers.Add(this.Term);
                 return containers;
+            }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Glossary"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
             }
         }
 

--- a/CDP4Common/AutoGenPoco/Glossary.cs
+++ b/CDP4Common/AutoGenPoco/Glossary.cs
@@ -131,8 +131,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Glossary"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Goal.cs
+++ b/CDP4Common/AutoGenPoco/Goal.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Goal.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -94,6 +94,29 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<Category> Category { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Goal"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="Goal"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/Goal.cs
+++ b/CDP4Common/AutoGenPoco/Goal.cs
@@ -99,8 +99,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Goal"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/HyperLink.cs
+++ b/CDP4Common/AutoGenPoco/HyperLink.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="HyperLink.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/IAnnotation.cs
+++ b/CDP4Common/AutoGenPoco/IAnnotation.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IAnnotation.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ICategorizableThing.cs
+++ b/CDP4Common/AutoGenPoco/ICategorizableThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ICategorizableThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/IDeprecatableThing.cs
+++ b/CDP4Common/AutoGenPoco/IDeprecatableThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IDeprecatableThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ILogEntry.cs
+++ b/CDP4Common/AutoGenPoco/ILogEntry.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ILogEntry.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/INamedThing.cs
+++ b/CDP4Common/AutoGenPoco/INamedThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="INamedThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/IOptionDependentThing.cs
+++ b/CDP4Common/AutoGenPoco/IOptionDependentThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IOptionDependentThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/IOwnedThing.cs
+++ b/CDP4Common/AutoGenPoco/IOwnedThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IOwnedThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/IParticipantAffectedAccessThing.cs
+++ b/CDP4Common/AutoGenPoco/IParticipantAffectedAccessThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IParticipantAffectedAccessThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/IShortNamedThing.cs
+++ b/CDP4Common/AutoGenPoco/IShortNamedThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IShortNamedThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ITimeStampedThing.cs
+++ b/CDP4Common/AutoGenPoco/ITimeStampedThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ITimeStampedThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/IVolatileThing.cs
+++ b/CDP4Common/AutoGenPoco/IVolatileThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IVolatileThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/IdCorrespondence.cs
+++ b/CDP4Common/AutoGenPoco/IdCorrespondence.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IdCorrespondence.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/InterfaceEndKind.cs
+++ b/CDP4Common/AutoGenPoco/InterfaceEndKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="InterfaceEndKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/IntervalScale.cs
+++ b/CDP4Common/AutoGenPoco/IntervalScale.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IntervalScale.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Iteration.cs
+++ b/CDP4Common/AutoGenPoco/Iteration.cs
@@ -347,8 +347,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Iteration"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Iteration.cs
+++ b/CDP4Common/AutoGenPoco/Iteration.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Iteration.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -341,6 +341,30 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.ValueGroup);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Iteration"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.DefaultOption;
+
+            yield return this.IterationSetup;
+
+            yield return this.TopElement;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/IterationSetup.cs
+++ b/CDP4Common/AutoGenPoco/IterationSetup.cs
@@ -157,8 +157,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="IterationSetup"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/IterationSetup.cs
+++ b/CDP4Common/AutoGenPoco/IterationSetup.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IterationSetup.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -152,6 +152,26 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public IterationSetup SourceIterationSetup { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="IterationSetup"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.SourceIterationSetup;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="IterationSetup"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/LinearConversionUnit.cs
+++ b/CDP4Common/AutoGenPoco/LinearConversionUnit.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="LinearConversionUnit.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/LogLevelKind.cs
+++ b/CDP4Common/AutoGenPoco/LogLevelKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="LogLevelKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/LogarithmBaseKind.cs
+++ b/CDP4Common/AutoGenPoco/LogarithmBaseKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="LogarithmBaseKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/LogarithmicScale.cs
+++ b/CDP4Common/AutoGenPoco/LogarithmicScale.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="LogarithmicScale.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -146,6 +146,26 @@ namespace CDP4Common.SiteDirectoryData
                 containers.Add(this.ReferenceQuantityValue);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="LogarithmicScale"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ReferenceQuantityKind;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/LogarithmicScale.cs
+++ b/CDP4Common/AutoGenPoco/LogarithmicScale.cs
@@ -152,8 +152,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="LogarithmicScale"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/MappingToReferenceScale.cs
+++ b/CDP4Common/AutoGenPoco/MappingToReferenceScale.cs
@@ -109,8 +109,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="MappingToReferenceScale"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/MappingToReferenceScale.cs
+++ b/CDP4Common/AutoGenPoco/MappingToReferenceScale.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MappingToReferenceScale.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -104,6 +104,28 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public ScaleValueDefinition ReferenceScaleValue { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="MappingToReferenceScale"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.DependentScaleValue;
+
+            yield return this.ReferenceScaleValue;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="MappingToReferenceScale"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/MeasurementScale.cs
+++ b/CDP4Common/AutoGenPoco/MeasurementScale.cs
@@ -220,8 +220,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="MeasurementScale"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/MeasurementScale.cs
+++ b/CDP4Common/AutoGenPoco/MeasurementScale.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MeasurementScale.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -214,6 +214,26 @@ namespace CDP4Common.SiteDirectoryData
                 containers.Add(this.ValueDefinition);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="MeasurementScale"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Unit;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/MeasurementUnit.cs
+++ b/CDP4Common/AutoGenPoco/MeasurementUnit.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MeasurementUnit.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ModelLogEntry.cs
+++ b/CDP4Common/AutoGenPoco/ModelLogEntry.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModelLogEntry.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -153,6 +153,31 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public LogLevelKind Level { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ModelLogEntry"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Author;
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ModelLogEntry"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ModelLogEntry.cs
+++ b/CDP4Common/AutoGenPoco/ModelLogEntry.cs
@@ -158,8 +158,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ModelLogEntry"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ModelReferenceDataLibrary.cs
+++ b/CDP4Common/AutoGenPoco/ModelReferenceDataLibrary.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModelReferenceDataLibrary.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ModellingAnnotationItem.cs
+++ b/CDP4Common/AutoGenPoco/ModellingAnnotationItem.cs
@@ -183,8 +183,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ModellingAnnotationItem"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ModellingAnnotationItem.cs
+++ b/CDP4Common/AutoGenPoco/ModellingAnnotationItem.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModellingAnnotationItem.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -176,6 +176,36 @@ namespace CDP4Common.ReportingData
                 var containers = new List<IEnumerable>(base.ContainerLists);
                 containers.Add(this.ApprovedBy);
                 return containers;
+            }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ModellingAnnotationItem"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
+
+            foreach (var thing in this.SourceAnnotation)
+            {
+                yield return thing;
             }
         }
 

--- a/CDP4Common/AutoGenPoco/ModellingThingReference.cs
+++ b/CDP4Common/AutoGenPoco/ModellingThingReference.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModellingThingReference.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/MultiRelationship.cs
+++ b/CDP4Common/AutoGenPoco/MultiRelationship.cs
@@ -100,8 +100,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="MultiRelationship"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/MultiRelationship.cs
+++ b/CDP4Common/AutoGenPoco/MultiRelationship.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MultiRelationship.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -95,6 +95,29 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<Thing> RelatedThing { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="MultiRelationship"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.RelatedThing)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="MultiRelationship"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/MultiRelationshipRule.cs
+++ b/CDP4Common/AutoGenPoco/MultiRelationshipRule.cs
@@ -128,8 +128,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="MultiRelationshipRule"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/MultiRelationshipRule.cs
+++ b/CDP4Common/AutoGenPoco/MultiRelationshipRule.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MultiRelationshipRule.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -123,6 +123,31 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public Category RelationshipCategory { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="MultiRelationshipRule"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.RelatedCategory)
+            {
+                yield return thing;
+            }
+
+            yield return this.RelationshipCategory;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="MultiRelationshipRule"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/NaturalLanguage.cs
+++ b/CDP4Common/AutoGenPoco/NaturalLanguage.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NaturalLanguage.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/NestedElement.cs
+++ b/CDP4Common/AutoGenPoco/NestedElement.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NestedElement.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -190,6 +190,31 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.NestedParameter);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="NestedElement"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.ElementUsage.Select(x => x))
+            {
+                yield return thing;
+            }
+
+            yield return this.RootElement;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/NestedElement.cs
+++ b/CDP4Common/AutoGenPoco/NestedElement.cs
@@ -196,8 +196,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="NestedElement"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/NestedParameter.cs
+++ b/CDP4Common/AutoGenPoco/NestedParameter.cs
@@ -161,8 +161,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="NestedParameter"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/NestedParameter.cs
+++ b/CDP4Common/AutoGenPoco/NestedParameter.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NestedParameter.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -155,6 +155,30 @@ namespace CDP4Common.EngineeringModelData
         {
             get { return this.GetDerivedPath(); }
             set { throw new InvalidOperationException("Forbidden Set value for the derived property NestedParameter.Path"); }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="NestedParameter"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ActualState;
+
+            yield return this.AssociatedParameter;
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/NotExpression.cs
+++ b/CDP4Common/AutoGenPoco/NotExpression.cs
@@ -97,8 +97,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="NotExpression"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/NotExpression.cs
+++ b/CDP4Common/AutoGenPoco/NotExpression.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NotExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -92,6 +92,26 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public BooleanExpression Term { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="NotExpression"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Term;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="NotExpression"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/Note.cs
+++ b/CDP4Common/AutoGenPoco/Note.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Note.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -136,6 +136,31 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public virtual string ShortName { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Note"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="Note"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/Note.cs
+++ b/CDP4Common/AutoGenPoco/Note.cs
@@ -141,8 +141,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Note"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/NumberSetKind.cs
+++ b/CDP4Common/AutoGenPoco/NumberSetKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NumberSetKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Option.cs
+++ b/CDP4Common/AutoGenPoco/Option.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Option.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -117,6 +117,29 @@ namespace CDP4Common.EngineeringModelData
                 var containers = new List<IEnumerable>(base.ContainerLists);
                 containers.Add(this.NestedElement);
                 return containers;
+            }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Option"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
             }
         }
 

--- a/CDP4Common/AutoGenPoco/Option.cs
+++ b/CDP4Common/AutoGenPoco/Option.cs
@@ -124,8 +124,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Option"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/OrExpression.cs
+++ b/CDP4Common/AutoGenPoco/OrExpression.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OrExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -93,6 +93,29 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<BooleanExpression> Term { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="OrExpression"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Term)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="OrExpression"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/OrExpression.cs
+++ b/CDP4Common/AutoGenPoco/OrExpression.cs
@@ -98,8 +98,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="OrExpression"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/OrdinalScale.cs
+++ b/CDP4Common/AutoGenPoco/OrdinalScale.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OrdinalScale.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Organization.cs
+++ b/CDP4Common/AutoGenPoco/Organization.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Organization.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/OwnedStyle.cs
+++ b/CDP4Common/AutoGenPoco/OwnedStyle.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OwnedStyle.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Page.cs
+++ b/CDP4Common/AutoGenPoco/Page.cs
@@ -165,8 +165,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Page"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Page.cs
+++ b/CDP4Common/AutoGenPoco/Page.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Page.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -159,6 +159,31 @@ namespace CDP4Common.ReportingData
                 containers.Add(this.Note);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Page"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Parameter.cs
+++ b/CDP4Common/AutoGenPoco/Parameter.cs
@@ -141,8 +141,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Parameter"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Parameter.cs
+++ b/CDP4Common/AutoGenPoco/Parameter.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Parameter.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -135,6 +135,26 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.ValueSet);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Parameter"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.RequestedBy;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterBase.cs
+++ b/CDP4Common/AutoGenPoco/ParameterBase.cs
@@ -144,8 +144,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterBase"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParameterBase.cs
+++ b/CDP4Common/AutoGenPoco/ParameterBase.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterBase.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -139,6 +139,34 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public virtual ActualFiniteStateList StateDependence { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterBase"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Group;
+
+            yield return this.Owner;
+
+            yield return this.ParameterType;
+
+            yield return this.Scale;
+
+            yield return this.StateDependence;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ParameterBase"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ParameterGroup.cs
+++ b/CDP4Common/AutoGenPoco/ParameterGroup.cs
@@ -109,8 +109,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterGroup"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParameterGroup.cs
+++ b/CDP4Common/AutoGenPoco/ParameterGroup.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterGroup.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -104,6 +104,26 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public string Name { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterGroup"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ContainingGroup;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ParameterGroup"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ParameterOrOverrideBase.cs
+++ b/CDP4Common/AutoGenPoco/ParameterOrOverrideBase.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterOrOverrideBase.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ParameterOverride.cs
+++ b/CDP4Common/AutoGenPoco/ParameterOverride.cs
@@ -202,8 +202,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterOverride"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParameterOverride.cs
+++ b/CDP4Common/AutoGenPoco/ParameterOverride.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterOverride.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -196,6 +196,26 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.ValueSet);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterOverride"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Parameter;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterOverrideValueSet.cs
+++ b/CDP4Common/AutoGenPoco/ParameterOverrideValueSet.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterOverrideValueSet.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -124,6 +124,26 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public ParameterValueSet ParameterValueSet { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterOverrideValueSet"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ParameterValueSet;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ParameterOverrideValueSet"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ParameterOverrideValueSet.cs
+++ b/CDP4Common/AutoGenPoco/ParameterOverrideValueSet.cs
@@ -129,8 +129,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterOverrideValueSet"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParameterSubscription.cs
+++ b/CDP4Common/AutoGenPoco/ParameterSubscription.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterSubscription.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ParameterSubscriptionValueSet.cs
+++ b/CDP4Common/AutoGenPoco/ParameterSubscriptionValueSet.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterSubscriptionValueSet.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -212,6 +212,26 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public ParameterSwitchKind ValueSwitch { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterSubscriptionValueSet"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.SubscribedValueSet;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ParameterSubscriptionValueSet"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ParameterSubscriptionValueSet.cs
+++ b/CDP4Common/AutoGenPoco/ParameterSubscriptionValueSet.cs
@@ -217,8 +217,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterSubscriptionValueSet"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParameterSwitchKind.cs
+++ b/CDP4Common/AutoGenPoco/ParameterSwitchKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterSwitchKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ParameterType.cs
+++ b/CDP4Common/AutoGenPoco/ParameterType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -130,6 +130,29 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public virtual string Symbol { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterType"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ParameterType"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ParameterType.cs
+++ b/CDP4Common/AutoGenPoco/ParameterType.cs
@@ -135,8 +135,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterType"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParameterTypeComponent.cs
+++ b/CDP4Common/AutoGenPoco/ParameterTypeComponent.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterTypeComponent.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -117,6 +117,28 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public string ShortName { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterTypeComponent"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ParameterType;
+
+            yield return this.Scale;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ParameterTypeComponent"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ParameterTypeComponent.cs
+++ b/CDP4Common/AutoGenPoco/ParameterTypeComponent.cs
@@ -122,8 +122,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterTypeComponent"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParameterValue.cs
+++ b/CDP4Common/AutoGenPoco/ParameterValue.cs
@@ -117,8 +117,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterValue"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParameterValue.cs
+++ b/CDP4Common/AutoGenPoco/ParameterValue.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterValue.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -112,6 +112,28 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: true, isNullable: false, isPersistent: true)]
         public virtual ValueArray<string> Value { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterValue"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ParameterType;
+
+            yield return this.Scale;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ParameterValue"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ParameterValueSet.cs
+++ b/CDP4Common/AutoGenPoco/ParameterValueSet.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterValueSet.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ParameterValueSetBase.cs
+++ b/CDP4Common/AutoGenPoco/ParameterValueSetBase.cs
@@ -212,8 +212,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterValueSetBase"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParameterValueSetBase.cs
+++ b/CDP4Common/AutoGenPoco/ParameterValueSetBase.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterValueSetBase.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -207,6 +207,28 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public virtual ParameterSwitchKind ValueSwitch { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterValueSetBase"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ActualOption;
+
+            yield return this.ActualState;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ParameterValueSetBase"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ParameterizedCategoryRule.cs
+++ b/CDP4Common/AutoGenPoco/ParameterizedCategoryRule.cs
@@ -107,8 +107,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterizedCategoryRule"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParameterizedCategoryRule.cs
+++ b/CDP4Common/AutoGenPoco/ParameterizedCategoryRule.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterizedCategoryRule.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -102,6 +102,31 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<ParameterType> ParameterType { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParameterizedCategoryRule"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Category;
+
+            foreach (var thing in this.ParameterType)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ParameterizedCategoryRule"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ParametricConstraint.cs
+++ b/CDP4Common/AutoGenPoco/ParametricConstraint.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParametricConstraint.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -130,6 +130,26 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.Expression);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParametricConstraint"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.TopExpression;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParametricConstraint.cs
+++ b/CDP4Common/AutoGenPoco/ParametricConstraint.cs
@@ -136,8 +136,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ParametricConstraint"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Participant.cs
+++ b/CDP4Common/AutoGenPoco/Participant.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Participant.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -136,6 +136,35 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public DomainOfExpertise SelectedDomain { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Participant"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Domain)
+            {
+                yield return thing;
+            }
+
+            yield return this.Person;
+
+            yield return this.Role;
+
+            yield return this.SelectedDomain;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="Participant"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/Participant.cs
+++ b/CDP4Common/AutoGenPoco/Participant.cs
@@ -141,8 +141,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Participant"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ParticipantAccessRightKind.cs
+++ b/CDP4Common/AutoGenPoco/ParticipantAccessRightKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParticipantAccessRightKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ParticipantPermission.cs
+++ b/CDP4Common/AutoGenPoco/ParticipantPermission.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParticipantPermission.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ParticipantRole.cs
+++ b/CDP4Common/AutoGenPoco/ParticipantRole.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParticipantRole.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Person.cs
+++ b/CDP4Common/AutoGenPoco/Person.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Person.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -269,6 +269,34 @@ namespace CDP4Common.SiteDirectoryData
                 containers.Add(this.UserPreference);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Person"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.DefaultDomain;
+
+            yield return this.DefaultEmailAddress;
+
+            yield return this.DefaultTelephoneNumber;
+
+            yield return this.Organization;
+
+            yield return this.Role;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Person.cs
+++ b/CDP4Common/AutoGenPoco/Person.cs
@@ -275,8 +275,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Person"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/PersonAccessRightKind.cs
+++ b/CDP4Common/AutoGenPoco/PersonAccessRightKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PersonAccessRightKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/PersonPermission.cs
+++ b/CDP4Common/AutoGenPoco/PersonPermission.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PersonPermission.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/PersonRole.cs
+++ b/CDP4Common/AutoGenPoco/PersonRole.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PersonRole.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Point.cs
+++ b/CDP4Common/AutoGenPoco/Point.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Point.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/PossibleFiniteState.cs
+++ b/CDP4Common/AutoGenPoco/PossibleFiniteState.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PossibleFiniteState.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/PossibleFiniteStateList.cs
+++ b/CDP4Common/AutoGenPoco/PossibleFiniteStateList.cs
@@ -150,8 +150,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="PossibleFiniteStateList"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/PossibleFiniteStateList.cs
+++ b/CDP4Common/AutoGenPoco/PossibleFiniteStateList.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PossibleFiniteStateList.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -144,6 +144,33 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.PossibleState);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="PossibleFiniteStateList"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.DefaultState;
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/PrefixedUnit.cs
+++ b/CDP4Common/AutoGenPoco/PrefixedUnit.cs
@@ -149,8 +149,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="PrefixedUnit"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/PrefixedUnit.cs
+++ b/CDP4Common/AutoGenPoco/PrefixedUnit.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PrefixedUnit.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -143,6 +143,26 @@ namespace CDP4Common.SiteDirectoryData
         {
             get { return this.GetDerivedShortName(); }
             set { throw new InvalidOperationException("Forbidden Set value for the derived property PrefixedUnit.ShortName"); }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="PrefixedUnit"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Prefix;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Publication.cs
+++ b/CDP4Common/AutoGenPoco/Publication.cs
@@ -125,8 +125,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Publication"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Publication.cs
+++ b/CDP4Common/AutoGenPoco/Publication.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Publication.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -120,6 +120,34 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<ParameterOrOverrideBase> PublishedParameter { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Publication"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Domain)
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.PublishedParameter)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="Publication"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/QuantityKind.cs
+++ b/CDP4Common/AutoGenPoco/QuantityKind.cs
@@ -177,8 +177,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="QuantityKind"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/QuantityKind.cs
+++ b/CDP4Common/AutoGenPoco/QuantityKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="QuantityKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -172,6 +172,31 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public virtual string QuantityDimensionSymbol { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="QuantityKind"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.DefaultScale;
+
+            foreach (var thing in this.PossibleScale)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="QuantityKind"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/QuantityKindFactor.cs
+++ b/CDP4Common/AutoGenPoco/QuantityKindFactor.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="QuantityKindFactor.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -101,6 +101,26 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public QuantityKind QuantityKind { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="QuantityKindFactor"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.QuantityKind;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="QuantityKindFactor"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/QuantityKindFactor.cs
+++ b/CDP4Common/AutoGenPoco/QuantityKindFactor.cs
@@ -106,8 +106,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="QuantityKindFactor"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/RatioScale.cs
+++ b/CDP4Common/AutoGenPoco/RatioScale.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RatioScale.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ReferenceDataLibrary.cs
+++ b/CDP4Common/AutoGenPoco/ReferenceDataLibrary.cs
@@ -261,8 +261,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ReferenceDataLibrary"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ReferenceDataLibrary.cs
+++ b/CDP4Common/AutoGenPoco/ReferenceDataLibrary.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ReferenceDataLibrary.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -255,6 +255,36 @@ namespace CDP4Common.SiteDirectoryData
                 containers.Add(this.UnitPrefix);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ReferenceDataLibrary"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.BaseQuantityKind.Select(x => x))
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.BaseUnit)
+            {
+                yield return thing;
+            }
+
+            yield return this.RequiredRdl;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ReferenceSource.cs
+++ b/CDP4Common/AutoGenPoco/ReferenceSource.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ReferenceSource.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -168,6 +168,33 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public string VersionIdentifier { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ReferenceSource"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.PublishedIn;
+
+            yield return this.Publisher;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ReferenceSource"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ReferenceSource.cs
+++ b/CDP4Common/AutoGenPoco/ReferenceSource.cs
@@ -173,8 +173,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ReferenceSource"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ReferencerRule.cs
+++ b/CDP4Common/AutoGenPoco/ReferencerRule.cs
@@ -128,8 +128,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ReferencerRule"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ReferencerRule.cs
+++ b/CDP4Common/AutoGenPoco/ReferencerRule.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ReferencerRule.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -123,6 +123,31 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public Category ReferencingCategory { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ReferencerRule"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.ReferencedCategory)
+            {
+                yield return thing;
+            }
+
+            yield return this.ReferencingCategory;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ReferencerRule"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/RelationalExpression.cs
+++ b/CDP4Common/AutoGenPoco/RelationalExpression.cs
@@ -126,8 +126,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="RelationalExpression"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/RelationalExpression.cs
+++ b/CDP4Common/AutoGenPoco/RelationalExpression.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationalExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -121,6 +121,28 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: true, isNullable: false, isPersistent: true)]
         public ValueArray<string> Value { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="RelationalExpression"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ParameterType;
+
+            yield return this.Scale;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="RelationalExpression"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/RelationalOperatorKind.cs
+++ b/CDP4Common/AutoGenPoco/RelationalOperatorKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationalOperatorKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Relationship.cs
+++ b/CDP4Common/AutoGenPoco/Relationship.cs
@@ -134,8 +134,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Relationship"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Relationship.cs
+++ b/CDP4Common/AutoGenPoco/Relationship.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Relationship.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -128,6 +128,31 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.ParameterValue);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Relationship"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/RelationshipParameterValue.cs
+++ b/CDP4Common/AutoGenPoco/RelationshipParameterValue.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationshipParameterValue.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/RequestForDeviation.cs
+++ b/CDP4Common/AutoGenPoco/RequestForDeviation.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequestForDeviation.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/RequestForWaiver.cs
+++ b/CDP4Common/AutoGenPoco/RequestForWaiver.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequestForWaiver.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Requirement.cs
+++ b/CDP4Common/AutoGenPoco/Requirement.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Requirement.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -137,6 +137,31 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.ParametricConstraint);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Requirement"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.Group;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Requirement.cs
+++ b/CDP4Common/AutoGenPoco/Requirement.cs
@@ -143,8 +143,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Requirement"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/RequirementsContainer.cs
+++ b/CDP4Common/AutoGenPoco/RequirementsContainer.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequirementsContainer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -140,6 +140,31 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.ParameterValue);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="RequirementsContainer"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/RequirementsContainer.cs
+++ b/CDP4Common/AutoGenPoco/RequirementsContainer.cs
@@ -146,8 +146,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="RequirementsContainer"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/RequirementsContainerParameterValue.cs
+++ b/CDP4Common/AutoGenPoco/RequirementsContainerParameterValue.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequirementsContainerParameterValue.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/RequirementsGroup.cs
+++ b/CDP4Common/AutoGenPoco/RequirementsGroup.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequirementsGroup.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/RequirementsSpecification.cs
+++ b/CDP4Common/AutoGenPoco/RequirementsSpecification.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RequirementsSpecification.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ReviewItemDiscrepancy.cs
+++ b/CDP4Common/AutoGenPoco/ReviewItemDiscrepancy.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ReviewItemDiscrepancy.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Rule.cs
+++ b/CDP4Common/AutoGenPoco/Rule.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Rule.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/RuleVerification.cs
+++ b/CDP4Common/AutoGenPoco/RuleVerification.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RuleVerification.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/RuleVerificationList.cs
+++ b/CDP4Common/AutoGenPoco/RuleVerificationList.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RuleVerificationList.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -116,6 +116,26 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.RuleVerification);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="RuleVerificationList"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/RuleVerificationList.cs
+++ b/CDP4Common/AutoGenPoco/RuleVerificationList.cs
@@ -122,8 +122,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="RuleVerificationList"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/RuleVerificationStatusKind.cs
+++ b/CDP4Common/AutoGenPoco/RuleVerificationStatusKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RuleVerificationStatusKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/RuleViolation.cs
+++ b/CDP4Common/AutoGenPoco/RuleViolation.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RuleViolation.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ScalarParameterType.cs
+++ b/CDP4Common/AutoGenPoco/ScalarParameterType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ScalarParameterType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ScaleReferenceQuantityValue.cs
+++ b/CDP4Common/AutoGenPoco/ScaleReferenceQuantityValue.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ScaleReferenceQuantityValue.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -101,6 +101,26 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public string Value { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ScaleReferenceQuantityValue"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Scale;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ScaleReferenceQuantityValue"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ScaleReferenceQuantityValue.cs
+++ b/CDP4Common/AutoGenPoco/ScaleReferenceQuantityValue.cs
@@ -106,8 +106,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ScaleReferenceQuantityValue"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ScaleValueDefinition.cs
+++ b/CDP4Common/AutoGenPoco/ScaleValueDefinition.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ScaleValueDefinition.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Section.cs
+++ b/CDP4Common/AutoGenPoco/Section.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Section.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -160,6 +160,31 @@ namespace CDP4Common.ReportingData
                 containers.Add(this.Page);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Section"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Section.cs
+++ b/CDP4Common/AutoGenPoco/Section.cs
@@ -166,8 +166,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Section"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/SharedStyle.cs
+++ b/CDP4Common/AutoGenPoco/SharedStyle.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SharedStyle.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/SimpleParameterValue.cs
+++ b/CDP4Common/AutoGenPoco/SimpleParameterValue.cs
@@ -135,8 +135,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SimpleParameterValue"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/SimpleParameterValue.cs
+++ b/CDP4Common/AutoGenPoco/SimpleParameterValue.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SimpleParameterValue.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -130,6 +130,28 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: true, isNullable: false, isPersistent: true)]
         public ValueArray<string> Value { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SimpleParameterValue"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ParameterType;
+
+            yield return this.Scale;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="SimpleParameterValue"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/SimpleParameterizableThing.cs
+++ b/CDP4Common/AutoGenPoco/SimpleParameterizableThing.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SimpleParameterizableThing.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -116,6 +116,26 @@ namespace CDP4Common.EngineeringModelData
                 containers.Add(this.ParameterValue);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SimpleParameterizableThing"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Owner;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/SimpleParameterizableThing.cs
+++ b/CDP4Common/AutoGenPoco/SimpleParameterizableThing.cs
@@ -122,8 +122,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SimpleParameterizableThing"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/SimpleQuantityKind.cs
+++ b/CDP4Common/AutoGenPoco/SimpleQuantityKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SimpleQuantityKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/SimpleUnit.cs
+++ b/CDP4Common/AutoGenPoco/SimpleUnit.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SimpleUnit.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/SiteDirectory.cs
+++ b/CDP4Common/AutoGenPoco/SiteDirectory.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteDirectory.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -281,6 +281,28 @@ namespace CDP4Common.SiteDirectoryData
                 containers.Add(this.SiteReferenceDataLibrary);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SiteDirectory"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.DefaultParticipantRole;
+
+            yield return this.DefaultPersonRole;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/SiteDirectory.cs
+++ b/CDP4Common/AutoGenPoco/SiteDirectory.cs
@@ -287,8 +287,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SiteDirectory"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/SiteDirectoryDataAnnotation.cs
+++ b/CDP4Common/AutoGenPoco/SiteDirectoryDataAnnotation.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteDirectoryDataAnnotation.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -135,6 +135,28 @@ namespace CDP4Common.ReportingData
                 containers.Add(this.RelatedThing);
                 return containers;
             }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SiteDirectoryDataAnnotation"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Author;
+
+            yield return this.PrimaryAnnotatedThing;
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/SiteDirectoryDataAnnotation.cs
+++ b/CDP4Common/AutoGenPoco/SiteDirectoryDataAnnotation.cs
@@ -141,8 +141,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SiteDirectoryDataAnnotation"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/SiteDirectoryDataDiscussionItem.cs
+++ b/CDP4Common/AutoGenPoco/SiteDirectoryDataDiscussionItem.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteDirectoryDataDiscussionItem.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -92,6 +92,26 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public Person Author { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SiteDirectoryDataDiscussionItem"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Author;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="SiteDirectoryDataDiscussionItem"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/SiteDirectoryDataDiscussionItem.cs
+++ b/CDP4Common/AutoGenPoco/SiteDirectoryDataDiscussionItem.cs
@@ -97,8 +97,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SiteDirectoryDataDiscussionItem"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/SiteDirectoryThingReference.cs
+++ b/CDP4Common/AutoGenPoco/SiteDirectoryThingReference.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteDirectoryThingReference.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/SiteLogEntry.cs
+++ b/CDP4Common/AutoGenPoco/SiteLogEntry.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteLogEntry.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -153,6 +153,31 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public LogLevelKind Level { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SiteLogEntry"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Author;
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="SiteLogEntry"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/SiteLogEntry.cs
+++ b/CDP4Common/AutoGenPoco/SiteLogEntry.cs
@@ -158,8 +158,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SiteLogEntry"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/SiteReferenceDataLibrary.cs
+++ b/CDP4Common/AutoGenPoco/SiteReferenceDataLibrary.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteReferenceDataLibrary.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Solution.cs
+++ b/CDP4Common/AutoGenPoco/Solution.cs
@@ -107,8 +107,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Solution"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/Solution.cs
+++ b/CDP4Common/AutoGenPoco/Solution.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Solution.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -102,6 +102,28 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public DomainOfExpertise Owner { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Solution"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Author;
+
+            yield return this.Owner;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="Solution"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/SpecializedQuantityKind.cs
+++ b/CDP4Common/AutoGenPoco/SpecializedQuantityKind.cs
@@ -100,8 +100,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SpecializedQuantityKind"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/SpecializedQuantityKind.cs
+++ b/CDP4Common/AutoGenPoco/SpecializedQuantityKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SpecializedQuantityKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -95,6 +95,26 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public QuantityKind General { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="SpecializedQuantityKind"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.General;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="SpecializedQuantityKind"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/StakeHolderValueMap.cs
+++ b/CDP4Common/AutoGenPoco/StakeHolderValueMap.cs
@@ -162,8 +162,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="StakeHolderValueMap"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/StakeHolderValueMap.cs
+++ b/CDP4Common/AutoGenPoco/StakeHolderValueMap.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="StakeHolderValueMap.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -155,6 +155,49 @@ namespace CDP4Common.EngineeringModelData
                 var containers = new List<IEnumerable>(base.ContainerLists);
                 containers.Add(this.Settings);
                 return containers;
+            }
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="StakeHolderValueMap"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Goal)
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Requirement)
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.StakeholderValue)
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.ValueGroup)
+            {
+                yield return thing;
             }
         }
 

--- a/CDP4Common/AutoGenPoco/StakeHolderValueMapSettings.cs
+++ b/CDP4Common/AutoGenPoco/StakeHolderValueMapSettings.cs
@@ -112,8 +112,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="StakeHolderValueMapSettings"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/StakeHolderValueMapSettings.cs
+++ b/CDP4Common/AutoGenPoco/StakeHolderValueMapSettings.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="StakeHolderValueMapSettings.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -107,6 +107,30 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public BinaryRelationshipRule ValueGroupToStakeholderValueRelationship { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="StakeHolderValueMapSettings"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.GoalToValueGroupRelationship;
+
+            yield return this.StakeholderValueToRequirementRelationship;
+
+            yield return this.ValueGroupToStakeholderValueRelationship;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="StakeHolderValueMapSettings"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/Stakeholder.cs
+++ b/CDP4Common/AutoGenPoco/Stakeholder.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Stakeholder.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -104,6 +104,34 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<StakeholderValue> StakeholderValue { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Stakeholder"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.StakeholderValue)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="Stakeholder"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/Stakeholder.cs
+++ b/CDP4Common/AutoGenPoco/Stakeholder.cs
@@ -109,8 +109,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Stakeholder"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/StakeholderValue.cs
+++ b/CDP4Common/AutoGenPoco/StakeholderValue.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="StakeholderValue.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -94,6 +94,29 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<Category> Category { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="StakeholderValue"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="StakeholderValue"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/StakeholderValue.cs
+++ b/CDP4Common/AutoGenPoco/StakeholderValue.cs
@@ -99,8 +99,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="StakeholderValue"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/StudyPhaseKind.cs
+++ b/CDP4Common/AutoGenPoco/StudyPhaseKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="StudyPhaseKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/TelephoneNumber.cs
+++ b/CDP4Common/AutoGenPoco/TelephoneNumber.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TelephoneNumber.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/Term.cs
+++ b/CDP4Common/AutoGenPoco/Term.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Term.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/TextParameterType.cs
+++ b/CDP4Common/AutoGenPoco/TextParameterType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TextParameterType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/TextualNote.cs
+++ b/CDP4Common/AutoGenPoco/TextualNote.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TextualNote.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/ThingReference.cs
+++ b/CDP4Common/AutoGenPoco/ThingReference.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ThingReference.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -99,6 +99,26 @@ namespace CDP4Common.ReportingData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public virtual Thing ReferencedThing { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ThingReference"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.ReferencedThing;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ThingReference"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/ThingReference.cs
+++ b/CDP4Common/AutoGenPoco/ThingReference.cs
@@ -104,8 +104,8 @@ namespace CDP4Common.ReportingData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ThingReference"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/TimeOfDayParameterType.cs
+++ b/CDP4Common/AutoGenPoco/TimeOfDayParameterType.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TimeOfDayParameterType.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/TopContainer.cs
+++ b/CDP4Common/AutoGenPoco/TopContainer.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="TopContainer.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/UnitFactor.cs
+++ b/CDP4Common/AutoGenPoco/UnitFactor.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="UnitFactor.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -101,6 +101,26 @@ namespace CDP4Common.SiteDirectoryData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public MeasurementUnit Unit { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="UnitFactor"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Unit;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="UnitFactor"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/UnitFactor.cs
+++ b/CDP4Common/AutoGenPoco/UnitFactor.cs
@@ -106,8 +106,8 @@ namespace CDP4Common.SiteDirectoryData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="UnitFactor"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/UnitPrefix.cs
+++ b/CDP4Common/AutoGenPoco/UnitPrefix.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="UnitPrefix.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/UserPreference.cs
+++ b/CDP4Common/AutoGenPoco/UserPreference.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="UserPreference.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/UserRuleVerification.cs
+++ b/CDP4Common/AutoGenPoco/UserRuleVerification.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="UserRuleVerification.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -107,6 +107,26 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public Rule Rule { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="UserRuleVerification"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            yield return this.Rule;
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="UserRuleVerification"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/UserRuleVerification.cs
+++ b/CDP4Common/AutoGenPoco/UserRuleVerification.cs
@@ -112,8 +112,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="UserRuleVerification"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ValueGroup.cs
+++ b/CDP4Common/AutoGenPoco/ValueGroup.cs
@@ -99,8 +99,8 @@ namespace CDP4Common.EngineeringModelData
         /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ValueGroup"/>
         /// </summary>
         /// <remarks>
-        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
-        /// are exposed via the <see cref="ContainerLists"/> method
+        /// This does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> property
         /// </remarks>
         /// <returns>
         /// An <see cref="IEnumerable{Thing}"/>

--- a/CDP4Common/AutoGenPoco/ValueGroup.cs
+++ b/CDP4Common/AutoGenPoco/ValueGroup.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ValueGroup.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //
@@ -94,6 +94,29 @@ namespace CDP4Common.EngineeringModelData
         /// </remarks>
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         public List<Category> Category { get; set; }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="ValueGroup"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
+        public override IEnumerable<Thing> QueryReferencedThings()
+        {
+            foreach (var thing in base.QueryReferencedThings())
+            {
+                yield return thing;
+            }
+
+            foreach (var thing in this.Category)
+            {
+                yield return thing;
+            }
+        }
 
         /// <summary>
         /// Creates and returns a copy of this <see cref="ValueGroup"/> for edit purpose.

--- a/CDP4Common/AutoGenPoco/VcardEmailAddressKind.cs
+++ b/CDP4Common/AutoGenPoco/VcardEmailAddressKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="VcardEmailAddressKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/AutoGenPoco/VcardTelephoneNumberKind.cs
+++ b/CDP4Common/AutoGenPoco/VcardTelephoneNumberKind.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="VcardTelephoneNumberKind.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//    Authors: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov, Smiechowski Nathanael
 //
 //    This file is part of CDP4-SDK Community Edition
 //

--- a/CDP4Common/Poco/Thing.cs
+++ b/CDP4Common/Poco/Thing.cs
@@ -150,7 +150,7 @@ namespace CDP4Common.CommonData
         [UmlInformation(aggregation: AggregationKind.None, isDerived: false, isOrdered: false, isNullable: false, isPersistent: true)]
         [DataMember]
         public virtual List<DomainOfExpertise> ExcludedDomain { get; set; }
-        
+
         /// <summary>
         /// Gets or sets a list of <see cref="Person"/> that are excluded for this instance.
         /// </summary>
@@ -237,7 +237,7 @@ namespace CDP4Common.CommonData
                 {
                     return this.cacheKey;
                 }
-                
+
                 var iterationContainer = this.GetContainerOfType<Iteration>();
                 Guid? iterationId = null;
                 if (iterationContainer != null && this.ClassKind != ClassKind.Iteration)
@@ -274,7 +274,7 @@ namespace CDP4Common.CommonData
             {
                 var currentType = this.GetType();
                 var typeName = currentType.Name;
-                
+
                 if (this is TopContainer)
                 {
                     if (typeName == "SiteDirectory" && this.Iid == Guid.Empty)
@@ -289,7 +289,7 @@ namespace CDP4Common.CommonData
                 {
                     return "no thing, no route";
                 }
-                 
+
                 var container = this.Container;
 
                 if (container == null)
@@ -334,6 +334,39 @@ namespace CDP4Common.CommonData
                     var containedThings = thing.QueryContainedThingsDeep();
                     temp.AddRange(containedThings);
                 }
+            }
+
+            return temp;
+        }
+
+        /// <summary>
+        /// Queries the referenced <see cref="Thing"/>s of the current <see cref="Thing"/>
+        /// </summary>
+        /// <remarks>
+        /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
+        /// are exposed via the <see cref="ContainerLists"/> method
+        /// </remarks>
+        /// <returns></returns>
+        public virtual IEnumerable<Thing> QueryReferencedThings()
+        {
+            return Enumerable.Empty<Thing>();
+        }
+
+        /// <summary>
+        /// Queries all the referenced <see cref="Thing"/>s of the current <see cref="Thing"/>, along the complete 
+        /// referenced <see cref="Thing"/> chain and returns them as a flat list
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/> 
+        /// </returns>
+        public IEnumerable<Thing> QueryReferencedThingsDeep()
+        {
+            var temp = new List<Thing>();
+
+            foreach (var thing in this.QueryReferencedThings())
+            {
+                temp.Add(thing);
+                temp.AddRange(thing.QueryReferencedThings());
             }
 
             return temp;

--- a/CDP4Common/Poco/Thing.cs
+++ b/CDP4Common/Poco/Thing.cs
@@ -346,7 +346,9 @@ namespace CDP4Common.CommonData
         /// this does not include the contained <see cref="Thing"/>s, the contained <see cref="Thing"/>s
         /// are exposed via the <see cref="ContainerLists"/> method
         /// </remarks>
-        /// <returns></returns>
+        /// <returns>
+        /// An <see cref="IEnumerable{Thing}"/>
+        /// </returns>
         public virtual IEnumerable<Thing> QueryReferencedThings()
         {
             return Enumerable.Empty<Thing>();

--- a/CDP4Common/Poco/Thing.cs
+++ b/CDP4Common/Poco/Thing.cs
@@ -367,11 +367,14 @@ namespace CDP4Common.CommonData
 
             foreach (var thing in this.QueryReferencedThings())
             {
-                temp.Add(thing);
-                temp.AddRange(thing.QueryReferencedThings());
+                if (thing != null)
+                {
+                    temp.Add(thing);
+                    temp.AddRange(thing.QueryReferencedThings());
+                }
             }
 
-            return temp;
+            return temp.Distinct();
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Added 2 methods on `Thing` class to enable future work on querying referenced things:
  - public virtual IEnumerable<Thing> QueryReferencedThings()
  - public IEnumerable<Thing> QueryReferencedThingsDeep()

<!-- Thanks for contributing to CDP4-SDK! -->