### PR TITLE
[Refactor] QueryReferencedThings to ignore null from result set

### DIFF
--- a/CDP4Common/AutoGenPoco/ActionItem.cs
+++ b/CDP4Common/AutoGenPoco/ActionItem.cs
@@ -137,7 +137,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Actionee;
+            if (this.Actionee != null)
+            {
+                yield return this.Actionee;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ActualFiniteStateList.cs
+++ b/CDP4Common/AutoGenPoco/ActualFiniteStateList.cs
@@ -197,7 +197,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
 
             foreach (var thing in this.PossibleFiniteStateList.Select(x => x))
             {

--- a/CDP4Common/AutoGenPoco/Approval.cs
+++ b/CDP4Common/AutoGenPoco/Approval.cs
@@ -129,9 +129,15 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Author;
+            if (this.Author != null)
+            {
+                yield return this.Author;
+            }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/BinaryNote.cs
+++ b/CDP4Common/AutoGenPoco/BinaryNote.cs
@@ -119,7 +119,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.FileType;
+            if (this.FileType != null)
+            {
+                yield return this.FileType;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/BinaryRelationship.cs
+++ b/CDP4Common/AutoGenPoco/BinaryRelationship.cs
@@ -119,9 +119,15 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Source;
+            if (this.Source != null)
+            {
+                yield return this.Source;
+            }
 
-            yield return this.Target;
+            if (this.Target != null)
+            {
+                yield return this.Target;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/BinaryRelationshipRule.cs
+++ b/CDP4Common/AutoGenPoco/BinaryRelationshipRule.cs
@@ -149,11 +149,20 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.RelationshipCategory;
+            if (this.RelationshipCategory != null)
+            {
+                yield return this.RelationshipCategory;
+            }
 
-            yield return this.SourceCategory;
+            if (this.SourceCategory != null)
+            {
+                yield return this.SourceCategory;
+            }
 
-            yield return this.TargetCategory;
+            if (this.TargetCategory != null)
+            {
+                yield return this.TargetCategory;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Book.cs
+++ b/CDP4Common/AutoGenPoco/Book.cs
@@ -184,7 +184,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ChangeProposal.cs
+++ b/CDP4Common/AutoGenPoco/ChangeProposal.cs
@@ -110,7 +110,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.ChangeRequest;
+            if (this.ChangeRequest != null)
+            {
+                yield return this.ChangeRequest;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Citation.cs
+++ b/CDP4Common/AutoGenPoco/Citation.cs
@@ -151,7 +151,10 @@ namespace CDP4Common.CommonData
                 yield return thing;
             }
 
-            yield return this.Source;
+            if (this.Source != null)
+            {
+                yield return this.Source;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Constant.cs
+++ b/CDP4Common/AutoGenPoco/Constant.cs
@@ -155,9 +155,15 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.ParameterType;
+            if (this.ParameterType != null)
+            {
+                yield return this.ParameterType;
+            }
 
-            yield return this.Scale;
+            if (this.Scale != null)
+            {
+                yield return this.Scale;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ContractChangeNotice.cs
+++ b/CDP4Common/AutoGenPoco/ContractChangeNotice.cs
@@ -110,7 +110,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.ChangeProposal;
+            if (this.ChangeProposal != null)
+            {
+                yield return this.ChangeProposal;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ConversionBasedUnit.cs
+++ b/CDP4Common/AutoGenPoco/ConversionBasedUnit.cs
@@ -118,7 +118,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.ReferenceUnit;
+            if (this.ReferenceUnit != null)
+            {
+                yield return this.ReferenceUnit;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/DecompositionRule.cs
+++ b/CDP4Common/AutoGenPoco/DecompositionRule.cs
@@ -148,7 +148,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.ContainingCategory;
+            if (this.ContainingCategory != null)
+            {
+                yield return this.ContainingCategory;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/DiagramEdge.cs
+++ b/CDP4Common/AutoGenPoco/DiagramEdge.cs
@@ -144,9 +144,15 @@ namespace CDP4Common.DiagramData
                 yield return thing;
             }
 
-            yield return this.Source;
+            if (this.Source != null)
+            {
+                yield return this.Source;
+            }
 
-            yield return this.Target;
+            if (this.Target != null)
+            {
+                yield return this.Target;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/DiagramElementThing.cs
+++ b/CDP4Common/AutoGenPoco/DiagramElementThing.cs
@@ -144,9 +144,15 @@ namespace CDP4Common.DiagramData
                 yield return thing;
             }
 
-            yield return this.DepictedThing;
+            if (this.DepictedThing != null)
+            {
+                yield return this.DepictedThing;
+            }
 
-            yield return this.SharedStyle;
+            if (this.SharedStyle != null)
+            {
+                yield return this.SharedStyle;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/DiagrammingStyle.cs
+++ b/CDP4Common/AutoGenPoco/DiagrammingStyle.cs
@@ -243,11 +243,20 @@ namespace CDP4Common.DiagramData
                 yield return thing;
             }
 
-            yield return this.FillColor;
+            if (this.FillColor != null)
+            {
+                yield return this.FillColor;
+            }
 
-            yield return this.FontColor;
+            if (this.FontColor != null)
+            {
+                yield return this.FontColor;
+            }
 
-            yield return this.StrokeColor;
+            if (this.StrokeColor != null)
+            {
+                yield return this.StrokeColor;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/DiscussionItem.cs
+++ b/CDP4Common/AutoGenPoco/DiscussionItem.cs
@@ -109,7 +109,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.ReplyTo;
+            if (this.ReplyTo != null)
+            {
+                yield return this.ReplyTo;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ElementBase.cs
+++ b/CDP4Common/AutoGenPoco/ElementBase.cs
@@ -125,7 +125,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ElementUsage.cs
+++ b/CDP4Common/AutoGenPoco/ElementUsage.cs
@@ -168,7 +168,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ElementDefinition;
+            if (this.ElementDefinition != null)
+            {
+                yield return this.ElementDefinition;
+            }
 
             foreach (var thing in this.ExcludeOption)
             {

--- a/CDP4Common/AutoGenPoco/EngineeringModel.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModel.cs
@@ -201,7 +201,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.EngineeringModelSetup;
+            if (this.EngineeringModelSetup != null)
+            {
+                yield return this.EngineeringModelSetup;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/EngineeringModelDataAnnotation.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModelDataAnnotation.cs
@@ -154,9 +154,15 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Author;
+            if (this.Author != null)
+            {
+                yield return this.Author;
+            }
 
-            yield return this.PrimaryAnnotatedThing;
+            if (this.PrimaryAnnotatedThing != null)
+            {
+                yield return this.PrimaryAnnotatedThing;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/EngineeringModelDataDiscussionItem.cs
+++ b/CDP4Common/AutoGenPoco/EngineeringModelDataDiscussionItem.cs
@@ -110,7 +110,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Author;
+            if (this.Author != null)
+            {
+                yield return this.Author;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ExternalIdentifierMap.cs
+++ b/CDP4Common/AutoGenPoco/ExternalIdentifierMap.cs
@@ -181,9 +181,15 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ExternalFormat;
+            if (this.ExternalFormat != null)
+            {
+                yield return this.ExternalFormat;
+            }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/File.cs
+++ b/CDP4Common/AutoGenPoco/File.cs
@@ -160,9 +160,15 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.LockedBy;
+            if (this.LockedBy != null)
+            {
+                yield return this.LockedBy;
+            }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/FileRevision.cs
+++ b/CDP4Common/AutoGenPoco/FileRevision.cs
@@ -180,9 +180,15 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ContainingFolder;
+            if (this.ContainingFolder != null)
+            {
+                yield return this.ContainingFolder;
+            }
 
-            yield return this.Creator;
+            if (this.Creator != null)
+            {
+                yield return this.Creator;
+            }
 
             foreach (var thing in this.FileType.Select(x => x))
             {

--- a/CDP4Common/AutoGenPoco/FileStore.cs
+++ b/CDP4Common/AutoGenPoco/FileStore.cs
@@ -165,7 +165,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Folder.cs
+++ b/CDP4Common/AutoGenPoco/Folder.cs
@@ -167,11 +167,20 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ContainingFolder;
+            if (this.ContainingFolder != null)
+            {
+                yield return this.ContainingFolder;
+            }
 
-            yield return this.Creator;
+            if (this.Creator != null)
+            {
+                yield return this.Creator;
+            }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Iteration.cs
+++ b/CDP4Common/AutoGenPoco/Iteration.cs
@@ -360,11 +360,20 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.DefaultOption;
+            if (this.DefaultOption != null)
+            {
+                yield return this.DefaultOption;
+            }
 
-            yield return this.IterationSetup;
+            if (this.IterationSetup != null)
+            {
+                yield return this.IterationSetup;
+            }
 
-            yield return this.TopElement;
+            if (this.TopElement != null)
+            {
+                yield return this.TopElement;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/IterationSetup.cs
+++ b/CDP4Common/AutoGenPoco/IterationSetup.cs
@@ -170,7 +170,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.SourceIterationSetup;
+            if (this.SourceIterationSetup != null)
+            {
+                yield return this.SourceIterationSetup;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/LogarithmicScale.cs
+++ b/CDP4Common/AutoGenPoco/LogarithmicScale.cs
@@ -165,7 +165,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.ReferenceQuantityKind;
+            if (this.ReferenceQuantityKind != null)
+            {
+                yield return this.ReferenceQuantityKind;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/MappingToReferenceScale.cs
+++ b/CDP4Common/AutoGenPoco/MappingToReferenceScale.cs
@@ -122,9 +122,15 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.DependentScaleValue;
+            if (this.DependentScaleValue != null)
+            {
+                yield return this.DependentScaleValue;
+            }
 
-            yield return this.ReferenceScaleValue;
+            if (this.ReferenceScaleValue != null)
+            {
+                yield return this.ReferenceScaleValue;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/MeasurementScale.cs
+++ b/CDP4Common/AutoGenPoco/MeasurementScale.cs
@@ -233,7 +233,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.Unit;
+            if (this.Unit != null)
+            {
+                yield return this.Unit;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ModelLogEntry.cs
+++ b/CDP4Common/AutoGenPoco/ModelLogEntry.cs
@@ -171,7 +171,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Author;
+            if (this.Author != null)
+            {
+                yield return this.Author;
+            }
 
             foreach (var thing in this.Category)
             {

--- a/CDP4Common/AutoGenPoco/ModellingAnnotationItem.cs
+++ b/CDP4Common/AutoGenPoco/ModellingAnnotationItem.cs
@@ -201,7 +201,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
 
             foreach (var thing in this.SourceAnnotation)
             {

--- a/CDP4Common/AutoGenPoco/MultiRelationshipRule.cs
+++ b/CDP4Common/AutoGenPoco/MultiRelationshipRule.cs
@@ -146,7 +146,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.RelationshipCategory;
+            if (this.RelationshipCategory != null)
+            {
+                yield return this.RelationshipCategory;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/NestedElement.cs
+++ b/CDP4Common/AutoGenPoco/NestedElement.cs
@@ -214,7 +214,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.RootElement;
+            if (this.RootElement != null)
+            {
+                yield return this.RootElement;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/NestedParameter.cs
+++ b/CDP4Common/AutoGenPoco/NestedParameter.cs
@@ -174,11 +174,20 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ActualState;
+            if (this.ActualState != null)
+            {
+                yield return this.ActualState;
+            }
 
-            yield return this.AssociatedParameter;
+            if (this.AssociatedParameter != null)
+            {
+                yield return this.AssociatedParameter;
+            }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/NotExpression.cs
+++ b/CDP4Common/AutoGenPoco/NotExpression.cs
@@ -110,7 +110,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Term;
+            if (this.Term != null)
+            {
+                yield return this.Term;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Note.cs
+++ b/CDP4Common/AutoGenPoco/Note.cs
@@ -159,7 +159,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Page.cs
+++ b/CDP4Common/AutoGenPoco/Page.cs
@@ -183,7 +183,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Parameter.cs
+++ b/CDP4Common/AutoGenPoco/Parameter.cs
@@ -154,7 +154,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.RequestedBy;
+            if (this.RequestedBy != null)
+            {
+                yield return this.RequestedBy;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterBase.cs
+++ b/CDP4Common/AutoGenPoco/ParameterBase.cs
@@ -157,15 +157,30 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Group;
+            if (this.Group != null)
+            {
+                yield return this.Group;
+            }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
 
-            yield return this.ParameterType;
+            if (this.ParameterType != null)
+            {
+                yield return this.ParameterType;
+            }
 
-            yield return this.Scale;
+            if (this.Scale != null)
+            {
+                yield return this.Scale;
+            }
 
-            yield return this.StateDependence;
+            if (this.StateDependence != null)
+            {
+                yield return this.StateDependence;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterGroup.cs
+++ b/CDP4Common/AutoGenPoco/ParameterGroup.cs
@@ -122,7 +122,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ContainingGroup;
+            if (this.ContainingGroup != null)
+            {
+                yield return this.ContainingGroup;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterOverride.cs
+++ b/CDP4Common/AutoGenPoco/ParameterOverride.cs
@@ -215,7 +215,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Parameter;
+            if (this.Parameter != null)
+            {
+                yield return this.Parameter;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterOverrideValueSet.cs
+++ b/CDP4Common/AutoGenPoco/ParameterOverrideValueSet.cs
@@ -142,7 +142,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ParameterValueSet;
+            if (this.ParameterValueSet != null)
+            {
+                yield return this.ParameterValueSet;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterSubscriptionValueSet.cs
+++ b/CDP4Common/AutoGenPoco/ParameterSubscriptionValueSet.cs
@@ -230,7 +230,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.SubscribedValueSet;
+            if (this.SubscribedValueSet != null)
+            {
+                yield return this.SubscribedValueSet;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterTypeComponent.cs
+++ b/CDP4Common/AutoGenPoco/ParameterTypeComponent.cs
@@ -135,9 +135,15 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.ParameterType;
+            if (this.ParameterType != null)
+            {
+                yield return this.ParameterType;
+            }
 
-            yield return this.Scale;
+            if (this.Scale != null)
+            {
+                yield return this.Scale;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterValue.cs
+++ b/CDP4Common/AutoGenPoco/ParameterValue.cs
@@ -130,9 +130,15 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ParameterType;
+            if (this.ParameterType != null)
+            {
+                yield return this.ParameterType;
+            }
 
-            yield return this.Scale;
+            if (this.Scale != null)
+            {
+                yield return this.Scale;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterValueSetBase.cs
+++ b/CDP4Common/AutoGenPoco/ParameterValueSetBase.cs
@@ -225,9 +225,15 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ActualOption;
+            if (this.ActualOption != null)
+            {
+                yield return this.ActualOption;
+            }
 
-            yield return this.ActualState;
+            if (this.ActualState != null)
+            {
+                yield return this.ActualState;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ParameterizedCategoryRule.cs
+++ b/CDP4Common/AutoGenPoco/ParameterizedCategoryRule.cs
@@ -120,7 +120,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.Category;
+            if (this.Category != null)
+            {
+                yield return this.Category;
+            }
 
             foreach (var thing in this.ParameterType)
             {

--- a/CDP4Common/AutoGenPoco/ParametricConstraint.cs
+++ b/CDP4Common/AutoGenPoco/ParametricConstraint.cs
@@ -149,7 +149,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.TopExpression;
+            if (this.TopExpression != null)
+            {
+                yield return this.TopExpression;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Participant.cs
+++ b/CDP4Common/AutoGenPoco/Participant.cs
@@ -159,11 +159,20 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.Person;
+            if (this.Person != null)
+            {
+                yield return this.Person;
+            }
 
-            yield return this.Role;
+            if (this.Role != null)
+            {
+                yield return this.Role;
+            }
 
-            yield return this.SelectedDomain;
+            if (this.SelectedDomain != null)
+            {
+                yield return this.SelectedDomain;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Person.cs
+++ b/CDP4Common/AutoGenPoco/Person.cs
@@ -288,15 +288,30 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.DefaultDomain;
+            if (this.DefaultDomain != null)
+            {
+                yield return this.DefaultDomain;
+            }
 
-            yield return this.DefaultEmailAddress;
+            if (this.DefaultEmailAddress != null)
+            {
+                yield return this.DefaultEmailAddress;
+            }
 
-            yield return this.DefaultTelephoneNumber;
+            if (this.DefaultTelephoneNumber != null)
+            {
+                yield return this.DefaultTelephoneNumber;
+            }
 
-            yield return this.Organization;
+            if (this.Organization != null)
+            {
+                yield return this.Organization;
+            }
 
-            yield return this.Role;
+            if (this.Role != null)
+            {
+                yield return this.Role;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/PossibleFiniteStateList.cs
+++ b/CDP4Common/AutoGenPoco/PossibleFiniteStateList.cs
@@ -168,9 +168,15 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.DefaultState;
+            if (this.DefaultState != null)
+            {
+                yield return this.DefaultState;
+            }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/PrefixedUnit.cs
+++ b/CDP4Common/AutoGenPoco/PrefixedUnit.cs
@@ -162,7 +162,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.Prefix;
+            if (this.Prefix != null)
+            {
+                yield return this.Prefix;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/QuantityKind.cs
+++ b/CDP4Common/AutoGenPoco/QuantityKind.cs
@@ -190,7 +190,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.DefaultScale;
+            if (this.DefaultScale != null)
+            {
+                yield return this.DefaultScale;
+            }
 
             foreach (var thing in this.PossibleScale)
             {

--- a/CDP4Common/AutoGenPoco/QuantityKindFactor.cs
+++ b/CDP4Common/AutoGenPoco/QuantityKindFactor.cs
@@ -119,7 +119,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.QuantityKind;
+            if (this.QuantityKind != null)
+            {
+                yield return this.QuantityKind;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ReferenceDataLibrary.cs
+++ b/CDP4Common/AutoGenPoco/ReferenceDataLibrary.cs
@@ -284,7 +284,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.RequiredRdl;
+            if (this.RequiredRdl != null)
+            {
+                yield return this.RequiredRdl;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ReferenceSource.cs
+++ b/CDP4Common/AutoGenPoco/ReferenceSource.cs
@@ -191,9 +191,15 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.PublishedIn;
+            if (this.PublishedIn != null)
+            {
+                yield return this.PublishedIn;
+            }
 
-            yield return this.Publisher;
+            if (this.Publisher != null)
+            {
+                yield return this.Publisher;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ReferencerRule.cs
+++ b/CDP4Common/AutoGenPoco/ReferencerRule.cs
@@ -146,7 +146,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.ReferencingCategory;
+            if (this.ReferencingCategory != null)
+            {
+                yield return this.ReferencingCategory;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/RelationalExpression.cs
+++ b/CDP4Common/AutoGenPoco/RelationalExpression.cs
@@ -139,9 +139,15 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ParameterType;
+            if (this.ParameterType != null)
+            {
+                yield return this.ParameterType;
+            }
 
-            yield return this.Scale;
+            if (this.Scale != null)
+            {
+                yield return this.Scale;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Relationship.cs
+++ b/CDP4Common/AutoGenPoco/Relationship.cs
@@ -152,7 +152,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Requirement.cs
+++ b/CDP4Common/AutoGenPoco/Requirement.cs
@@ -161,7 +161,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Group;
+            if (this.Group != null)
+            {
+                yield return this.Group;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/RequirementsContainer.cs
+++ b/CDP4Common/AutoGenPoco/RequirementsContainer.cs
@@ -164,7 +164,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/RuleVerificationList.cs
+++ b/CDP4Common/AutoGenPoco/RuleVerificationList.cs
@@ -135,7 +135,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ScaleReferenceQuantityValue.cs
+++ b/CDP4Common/AutoGenPoco/ScaleReferenceQuantityValue.cs
@@ -119,7 +119,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.Scale;
+            if (this.Scale != null)
+            {
+                yield return this.Scale;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/Section.cs
+++ b/CDP4Common/AutoGenPoco/Section.cs
@@ -184,7 +184,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/SimpleParameterValue.cs
+++ b/CDP4Common/AutoGenPoco/SimpleParameterValue.cs
@@ -148,9 +148,15 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.ParameterType;
+            if (this.ParameterType != null)
+            {
+                yield return this.ParameterType;
+            }
 
-            yield return this.Scale;
+            if (this.Scale != null)
+            {
+                yield return this.Scale;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/SimpleParameterizableThing.cs
+++ b/CDP4Common/AutoGenPoco/SimpleParameterizableThing.cs
@@ -135,7 +135,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/SiteDirectory.cs
+++ b/CDP4Common/AutoGenPoco/SiteDirectory.cs
@@ -300,9 +300,15 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.DefaultParticipantRole;
+            if (this.DefaultParticipantRole != null)
+            {
+                yield return this.DefaultParticipantRole;
+            }
 
-            yield return this.DefaultPersonRole;
+            if (this.DefaultPersonRole != null)
+            {
+                yield return this.DefaultPersonRole;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/SiteDirectoryDataAnnotation.cs
+++ b/CDP4Common/AutoGenPoco/SiteDirectoryDataAnnotation.cs
@@ -154,9 +154,15 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Author;
+            if (this.Author != null)
+            {
+                yield return this.Author;
+            }
 
-            yield return this.PrimaryAnnotatedThing;
+            if (this.PrimaryAnnotatedThing != null)
+            {
+                yield return this.PrimaryAnnotatedThing;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/SiteDirectoryDataDiscussionItem.cs
+++ b/CDP4Common/AutoGenPoco/SiteDirectoryDataDiscussionItem.cs
@@ -110,7 +110,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Author;
+            if (this.Author != null)
+            {
+                yield return this.Author;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/SiteLogEntry.cs
+++ b/CDP4Common/AutoGenPoco/SiteLogEntry.cs
@@ -171,7 +171,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.Author;
+            if (this.Author != null)
+            {
+                yield return this.Author;
+            }
 
             foreach (var thing in this.Category)
             {

--- a/CDP4Common/AutoGenPoco/Solution.cs
+++ b/CDP4Common/AutoGenPoco/Solution.cs
@@ -120,9 +120,15 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.Author;
+            if (this.Author != null)
+            {
+                yield return this.Author;
+            }
 
-            yield return this.Owner;
+            if (this.Owner != null)
+            {
+                yield return this.Owner;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/SpecializedQuantityKind.cs
+++ b/CDP4Common/AutoGenPoco/SpecializedQuantityKind.cs
@@ -113,7 +113,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.General;
+            if (this.General != null)
+            {
+                yield return this.General;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/StakeHolderValueMapSettings.cs
+++ b/CDP4Common/AutoGenPoco/StakeHolderValueMapSettings.cs
@@ -125,11 +125,20 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.GoalToValueGroupRelationship;
+            if (this.GoalToValueGroupRelationship != null)
+            {
+                yield return this.GoalToValueGroupRelationship;
+            }
 
-            yield return this.StakeholderValueToRequirementRelationship;
+            if (this.StakeholderValueToRequirementRelationship != null)
+            {
+                yield return this.StakeholderValueToRequirementRelationship;
+            }
 
-            yield return this.ValueGroupToStakeholderValueRelationship;
+            if (this.ValueGroupToStakeholderValueRelationship != null)
+            {
+                yield return this.ValueGroupToStakeholderValueRelationship;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/ThingReference.cs
+++ b/CDP4Common/AutoGenPoco/ThingReference.cs
@@ -117,7 +117,10 @@ namespace CDP4Common.ReportingData
                 yield return thing;
             }
 
-            yield return this.ReferencedThing;
+            if (this.ReferencedThing != null)
+            {
+                yield return this.ReferencedThing;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/UnitFactor.cs
+++ b/CDP4Common/AutoGenPoco/UnitFactor.cs
@@ -119,7 +119,10 @@ namespace CDP4Common.SiteDirectoryData
                 yield return thing;
             }
 
-            yield return this.Unit;
+            if (this.Unit != null)
+            {
+                yield return this.Unit;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/AutoGenPoco/UserRuleVerification.cs
+++ b/CDP4Common/AutoGenPoco/UserRuleVerification.cs
@@ -125,7 +125,10 @@ namespace CDP4Common.EngineeringModelData
                 yield return thing;
             }
 
-            yield return this.Rule;
+            if (this.Rule != null)
+            {
+                yield return this.Rule;
+            }
         }
 
         /// <summary>

--- a/CDP4Common/Poco/Thing.cs
+++ b/CDP4Common/Poco/Thing.cs
@@ -367,11 +367,8 @@ namespace CDP4Common.CommonData
 
             foreach (var thing in this.QueryReferencedThings())
             {
-                if (thing != null)
-                {
-                    temp.Add(thing);
-                    temp.AddRange(thing.QueryReferencedThings());
-                }
+                temp.Add(thing);
+                temp.AddRange(thing.QueryReferencedThings());
             }
 
             return temp.Distinct();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
In the previous implementation the properties with [0..1] where also added even when the value = null. This has been fixed, only the value (always an instance of `Thing`) of properties that are not null are returned in the QueryReferencedThings method. The QueryReferencedThingsDeep method on `Thing` has been updated accordingly

<!-- Thanks for contributing to CDP4-SDK! -->