### PR TITLE
[Fix] Uri contexts are no longer ignored when logging in. Fixes IME#571

### DIFF
--- a/CDP4Dal.NetCore.Tests/DAL/DalTestFixture.cs
+++ b/CDP4Dal.NetCore.Tests/DAL/DalTestFixture.cs
@@ -46,6 +46,7 @@ namespace CDP4Dal.Tests.DAL
     {
         private Credentials credentials;
         private string someURI = "http://someURI";
+        private string somePath = "SiteDirectory";
         private string filePath;
 
         [SetUp]
@@ -74,6 +75,54 @@ namespace CDP4Dal.Tests.DAL
             Assert.AreEqual(this.someURI, dal.CleanSlashes(uriWithTrailingSlash));
             Assert.AreEqual(string.Empty, dal.CleanSlashes(string.Empty));
             Assert.AreEqual(string.Empty, dal.CleanSlashes(null));
+        }
+
+        [Test]
+        public void Verify_That_Clean_Path_Start_Slash_Removes_First_Slash_From_Path()
+        {
+            var dal = new TestDal(this.credentials);
+
+            var pathWithSlash = $"/{this.somePath}";
+
+            Assert.AreEqual(this.somePath, dal.CleanPathSlashes(this.somePath));
+            Assert.AreEqual(this.somePath, dal.CleanPathSlashes(pathWithSlash));
+            Assert.AreEqual(string.Empty, dal.CleanPathSlashes(string.Empty));
+            Assert.AreEqual(string.Empty, dal.CleanPathSlashes(null));
+        }
+
+        [Test]
+        public void Verify_That_UriBuilder_Constructs_Proper_Uris()
+        {
+            var dal = new TestDal(this.credentials);
+
+            var pathWithSlash = $"/{this.somePath}";
+            var correctFullUri = "http://someuri:80/SiteDirectory";
+
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithSlash).ToString());
+
+            this.credentials = new Credentials("John", "Doe", new Uri("http://someURI/"));
+
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithSlash).ToString());
+
+            var pathWithoutSlash = $"{this.somePath}";
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithoutSlash).ToString());
+
+            this.credentials = new Credentials("John", "Doe", new Uri("http://someURI/mdb/"));
+            correctFullUri = "http://someuri:80/mdb/SiteDirectory";
+
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithoutSlash).ToString());
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithSlash).ToString());
+
+            this.credentials = new Credentials("John", "Doe", new Uri("http://someURI/mdb/a/b/c"));
+            correctFullUri = "http://someuri:80/mdb/a/b/c/SiteDirectory";
+
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithoutSlash).ToString());
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithSlash).ToString());
+
+            this.credentials = new Credentials("John", "Doe", new Uri("http://someURI/mdb/a/b/c/"));
+
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithoutSlash).ToString());
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithSlash).ToString());
         }
 
         [Test]
@@ -260,6 +309,16 @@ namespace CDP4Dal.Tests.DAL
         public string CleanSlashes(string uri)
         {
             return base.CleanUriFinalSlash(uri);
+        }
+
+        public string CleanPathSlashes(string path)
+        {
+            return base.CleanPathStartingSlash(path);
+        }
+
+        public UriBuilder GetBuilder(Uri uri, string path)
+        {
+            return base.GetUriBuilder(uri, path);
         }
 
         internal void TestOperationContainerFileVerification(OperationContainer operationContainer, IEnumerable<string> files)

--- a/CDP4Dal.Tests/DAL/DalTestFixture.cs
+++ b/CDP4Dal.Tests/DAL/DalTestFixture.cs
@@ -46,6 +46,7 @@ namespace CDP4Dal.Tests.DAL
     {
         private Credentials credentials;
         private string someURI = "http://someURI";
+        private string somePath = "SiteDirectory";
         private string filePath;
 
         [SetUp]
@@ -74,6 +75,54 @@ namespace CDP4Dal.Tests.DAL
             Assert.AreEqual(this.someURI, dal.CleanSlashes(uriWithTrailingSlash));
             Assert.AreEqual(string.Empty, dal.CleanSlashes(string.Empty));
             Assert.AreEqual(string.Empty, dal.CleanSlashes(null));
+        }
+
+        [Test]
+        public void Verify_That_Clean_Path_Start_Slash_Removes_First_Slash_From_Path()
+        {
+            var dal = new TestDal(this.credentials);
+
+            var pathWithSlash = $"/{this.somePath}";
+
+            Assert.AreEqual(this.somePath, dal.CleanPathSlashes(this.somePath));
+            Assert.AreEqual(this.somePath, dal.CleanPathSlashes(pathWithSlash));
+            Assert.AreEqual(string.Empty, dal.CleanPathSlashes(string.Empty));
+            Assert.AreEqual(string.Empty, dal.CleanPathSlashes(null));
+        }
+
+        [Test]
+        public void Verify_That_UriBuilder_Constructs_Proper_Uris()
+        {
+            var dal = new TestDal(this.credentials);
+
+            var pathWithSlash = $"/{this.somePath}";
+            var correctFullUri = "http://someuri:80/SiteDirectory";
+
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithSlash).ToString());
+
+            this.credentials = new Credentials("John", "Doe", new Uri("http://someURI/"));
+
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithSlash).ToString());
+
+            var pathWithoutSlash = $"{this.somePath}";
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithoutSlash).ToString());
+
+            this.credentials = new Credentials("John", "Doe", new Uri("http://someURI/mdb/"));
+            correctFullUri = "http://someuri:80/mdb/SiteDirectory";
+
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithoutSlash).ToString());
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithSlash).ToString());
+
+            this.credentials = new Credentials("John", "Doe", new Uri("http://someURI/mdb/a/b/c"));
+            correctFullUri = "http://someuri:80/mdb/a/b/c/SiteDirectory";
+
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithoutSlash).ToString());
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithSlash).ToString());
+
+            this.credentials = new Credentials("John", "Doe", new Uri("http://someURI/mdb/a/b/c/"));
+
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithoutSlash).ToString());
+            Assert.AreEqual(correctFullUri, dal.GetBuilder(this.credentials.Uri, pathWithSlash).ToString());
         }
 
         [Test]
@@ -260,6 +309,16 @@ namespace CDP4Dal.Tests.DAL
         public string CleanSlashes(string uri)
         {
             return base.CleanUriFinalSlash(uri);
+        }
+
+        public string CleanPathSlashes(string path)
+        {
+            return base.CleanPathStartingSlash(path);
+        }
+
+        public UriBuilder GetBuilder(Uri uri, string path)
+        {
+            return base.GetUriBuilder(uri, path);
         }
 
         internal void TestOperationContainerFileVerification(OperationContainer operationContainer, IEnumerable<string> files)

--- a/CDP4Dal/DAL/Dal.cs
+++ b/CDP4Dal/DAL/Dal.cs
@@ -254,7 +254,7 @@ namespace CDP4Dal.DAL
         /// The uri to clean up.
         /// </param>
         /// <returns>
-        /// The <see cref="string"/> consisting of either the uri.
+        /// The <see cref="string"/> consisting of the uri without the final /
         /// </returns>
         protected string CleanUriFinalSlash(string uri)
         {
@@ -264,6 +264,42 @@ namespace CDP4Dal.DAL
             }
 
             return uri.EndsWith("/") ? uri.TrimEnd(uri[uri.Length - 1]) : uri;
+        }
+
+        /// <summary>
+        /// If the given path starts with '/' remove it.
+        /// </summary>
+        /// <param name="uri">
+        /// The path to clean up.
+        /// </param>
+        /// <returns>
+        /// The <see cref="string"/> consisting of the cleaned up path.
+        /// </returns>
+        protected string CleanPathStartingSlash(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return string.Empty;
+            }
+
+            return path.StartsWith("/") ? path.TrimStart(path[0]) : path;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="UriBuilder"/> object with appropriate base and paths set, accounting that the original uri might have
+        /// subpaths in it already
+        /// </summary>
+        /// <param name="uri">The base uri (including subpaths)</param>
+        /// <param name="path">The path to be appended.</param>
+        /// <returns>A complete <see cref="UriBuilder"/> object.</returns>
+        protected UriBuilder GetUriBuilder(Uri uri, string path)
+        {
+            var cleanPath = this.CleanPathStartingSlash(path);
+
+            var result = new UriBuilder(uri);
+
+            result.Path = $"{result.Path}{(result.Path.EndsWith("/") ? string.Empty : "/")}{cleanPath}";
+            return result;
         }
 
         /// <summary>

--- a/CDP4Dal/DAL/Dal.cs
+++ b/CDP4Dal/DAL/Dal.cs
@@ -269,7 +269,7 @@ namespace CDP4Dal.DAL
         /// <summary>
         /// If the given path starts with '/' remove it.
         /// </summary>
-        /// <param name="uri">
+        /// <param name="path">
         /// The path to clean up.
         /// </param>
         /// <returns>

--- a/CDP4ServicesDal/CdpServicesDal.cs
+++ b/CDP4ServicesDal/CdpServicesDal.cs
@@ -142,7 +142,8 @@ namespace CDP4ServicesDal
 
             var postToken = operationContainer.Token;
             var resourcePath = $"{operationContainer.Context}{attribute}";
-            var uriBuilder = new UriBuilder(this.Credentials.Uri) { Path = resourcePath };
+
+            var uriBuilder = this.GetUriBuilder(this.Credentials.Uri, resourcePath);
             Logger.Debug("CDP4 Services POST: {0} - {1}", postToken, uriBuilder);
 
             var requestContent = this.CreateHttpContent(postToken, operationContainer, files);
@@ -278,7 +279,7 @@ namespace CDP4ServicesDal
             var resourcePath = $"{thingRoute}?includeFileData=true";
 
             var readToken = CDP4Common.Helpers.TokenGenerator.GenerateRandomToken();
-            var uriBuilder = new UriBuilder(this.Credentials.Uri) { Path = resourcePath };
+            var uriBuilder = this.GetUriBuilder(this.Credentials.Uri, resourcePath);
             Logger.Debug("CDP4Services GET {0}: {1}", readToken, uriBuilder);
 
             var requestsw = Stopwatch.StartNew();
@@ -361,7 +362,7 @@ namespace CDP4ServicesDal
             var resourcePath = $"{thingRoute}{attributes?.ToString()}";
 
             var readToken = CDP4Common.Helpers.TokenGenerator.GenerateRandomToken();
-            var uriBuilder = new UriBuilder(this.Credentials.Uri) { Path = resourcePath };
+            var uriBuilder = this.GetUriBuilder(this.Credentials.Uri, resourcePath);
             Logger.Debug("CDP4Services GET {0}: {1}", readToken, uriBuilder);
 
             var requestsw = Stopwatch.StartNew();
@@ -491,7 +492,7 @@ namespace CDP4ServicesDal
 
             var watch = Stopwatch.StartNew();
             
-            var uriBuilder = new UriBuilder(credentials.Uri) { Path = resourcePath };
+            var uriBuilder = this.GetUriBuilder(credentials.Uri, resourcePath);
             Logger.Debug("CDP4Services Open {0}: {1}", openToken, uriBuilder);
 
             var requestsw = Stopwatch.StartNew();

--- a/CDP4WspDal/WSPDal.cs
+++ b/CDP4WspDal/WSPDal.cs
@@ -156,7 +156,7 @@ namespace CDP4WspDal
 
             var postToken = operationContainer.Token;
             var resourcePath = $"{operationContainer.Context}{attribute}";
-            var uriBuilder = new UriBuilder(this.Credentials.Uri) { Path = resourcePath };
+            var uriBuilder = this.GetUriBuilder(this.Credentials.Uri, resourcePath);
             Logger.Debug("WSP Dal POST: {0} - {1}", postToken, uriBuilder);
 
             var requestContent = this.CreateHttpContent(postToken, operationContainer, files);
@@ -338,7 +338,7 @@ namespace CDP4WspDal
             var resourcePath = $"{thingRoute}{attributes.ToString()}";
 
             var readToken = CDP4Common.Helpers.TokenGenerator.GenerateRandomToken();
-            var uriBuilder = new UriBuilder(this.Credentials.Uri) { Path = resourcePath };
+            var uriBuilder = this.GetUriBuilder(this.Credentials.Uri, resourcePath);
             Logger.Debug("WSP GET {0}: {1}", readToken, uriBuilder);
 
             var requestsw = Stopwatch.StartNew();
@@ -464,7 +464,7 @@ namespace CDP4WspDal
             
             var watch = Stopwatch.StartNew();
             
-            var uriBuilder = new UriBuilder(credentials.Uri) { Path = resourcePath };
+            var uriBuilder = this.GetUriBuilder(credentials.Uri, resourcePath);
             Logger.Debug("WSP Open {0}: {1}", openToken, uriBuilder);
 
             var requestsw = Stopwatch.StartNew();

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
 image: Visual Studio 2019
+version: 1.0.{build}
+
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -56,6 +58,11 @@ before_build:
 build_script:
   - cmd: dotnet build CDP4-SDK-NETF.sln --configuration %CONFIGURATION% -v q --framework net45
   - cmd: dotnet build CDP4-SDK-NETC.sln --configuration %CONFIGURATION% -v q --framework netcoreapp3.1
+  - ps: >-
+      if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+        Write-Host Building Nugets PR# $env:APPVEYOR_PULL_REQUEST_NUMBER
+        dotnet pack CDP4-SDK-NETF.sln --configuration %CONFIGURATION% --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_REPO_COMMIT_TIMESTAMP"
+      }
 
 test_script:
     - >
@@ -76,6 +83,14 @@ after_test:
         dotnet sonarscanner end /d:"sonar.login=$env:SONARCLOUD_TOKEN"
       }
   - xcopy /q /Y /I "%TEST_COVERAGE%" "%TEST_LOG%\"
+
+deploy:
+  - provider: NuGet
+    server: https://nuget.pkg.github.com/RHEAGROUP/index.json
+    artifact: /.nupkg/
+    username: RHEAGROUP
+    api_key:
+      secure: uS7/WlBplrAs/j9ab9P3SUN7GZyf4QAHZX//YpDOzXG/DZ6o1MGHdIWLHHdDYM5P
 
 artifacts:
     - path: '%TEST_LOG%'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,13 +87,17 @@ after_test:
 deploy:
   - provider: NuGet
     server: https://nuget.pkg.github.com/RHEAGROUP/index.json
-    artifact: /.nupkg/
+    artifact: /.*(\.|\.s)nupkg/
     username: RHEAGROUP
     api_key:
       secure: uS7/WlBplrAs/j9ab9P3SUN7GZyf4QAHZX//YpDOzXG/DZ6o1MGHdIWLHHdDYM5P
 
 artifacts:
     - path: '%TEST_LOG%'
+      name: test logs
+
+    - path: '**\*.nupkg'
+      name: builds
 
 notifications:
   - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ build_script:
   - ps: >-
       if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
         Write-Host Building Nugets PR# $env:APPVEYOR_PULL_REQUEST_NUMBER
-        dotnet pack CDP4-SDK-NETF.sln --configuration %CONFIGURATION% --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_REPO_COMMIT_TIMESTAMP"
+        dotnet pack CDP4-SDK-NETF.sln --configuration $env:%CONFIGURATION% --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_REPO_COMMIT_TIMESTAMP"
       }
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ build_script:
   - ps: >-
       if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
         Write-Host Building Nugets PR# $env:APPVEYOR_PULL_REQUEST_NUMBER
-        dotnet pack CDP4-SDK-NETF.sln --configuration $env:CONFIGURATION --no-build --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_BUILD_NUMBER"
+        dotnet pack CDP4-SDK-NETF.sln --configuration $env:CONFIGURATION -p:TargetFrameworks=net45 --no-build --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_BUILD_NUMBER"
       }
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ build_script:
   - ps: >-
       if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
         Write-Host Building Nugets PR# $env:APPVEYOR_PULL_REQUEST_NUMBER
-        dotnet pack CDP4-SDK-NETF.sln --configuration $env:CONFIGURATION --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_BUILD_NUMBER"
+        dotnet pack CDP4-SDK-NETF.sln --configuration $env:CONFIGURATION --no-build --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_BUILD_NUMBER"
       }
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ build_script:
   - ps: >-
       if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
         Write-Host Building Nugets PR# $env:APPVEYOR_PULL_REQUEST_NUMBER
-        dotnet pack CDP4-SDK-NETF.sln --configuration $env:CONFIGURATION --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_REPO_COMMIT_TIMESTAMP"
+        dotnet pack CDP4-SDK-NETF.sln --configuration $env:CONFIGURATION --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_BUILD_NUMBER"
       }
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ build_script:
   - ps: >-
       if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
         Write-Host Building Nugets PR# $env:APPVEYOR_PULL_REQUEST_NUMBER
-        dotnet pack CDP4-SDK-NETF.sln --configuration $env:%CONFIGURATION% --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_REPO_COMMIT_TIMESTAMP"
+        dotnet pack CDP4-SDK-NETF.sln --configuration $env:CONFIGURATION --include-symbols --version-suffix "PR$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_REPO_COMMIT_TIMESTAMP"
       }
 
 test_script:


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The UriBuilder usage refactored not to lose folders in server uri's. connected to https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/issues/571

<!-- Thanks for contributing to CDP4-SDK! -->