### PR TITLE
[Add] NET48 to compiler conditional statement

### DIFF
--- a/CDP4Common/Polyfills/TypePolyfills.cs
+++ b/CDP4Common/Polyfills/TypePolyfills.cs
@@ -27,7 +27,7 @@ namespace CDP4Common.Polyfills
     using System;
     using System.Reflection;
 
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
 
     /// <summary>
     /// The purpose of the <see cref="TypePolyfills"/> class is to provide extension methods on the <see cref="Type"/>

--- a/CDP4Dal/AvailableDals.cs
+++ b/CDP4Dal/AvailableDals.cs
@@ -26,7 +26,7 @@ namespace CDP4Dal
 {
     using System;
     using System.Collections.Generic;
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
     using System.ComponentModel.Composition;
 #endif
     using CDP4Dal.Composition;
@@ -35,7 +35,7 @@ namespace CDP4Dal
     /// <summary>
     /// Instantiated by MEF to provide a list of <see cref="IDal"/> available in the application
     /// </summary>
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
     [Export(typeof(AvailableDals))]
     [PartCreationPolicy(CreationPolicy.Shared)]
 #endif
@@ -45,7 +45,7 @@ namespace CDP4Dal
         /// Initializes a new instance of the <see cref="AvailableDals"/> class
         /// </summary>
         /// <param name="dataAccessLayerKinds">the list of <see cref="IDal"/> in the application</param>
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
         [ImportingConstructor]
         public AvailableDals([ImportMany] IEnumerable<Lazy<IDal, IDalMetaData>> dataAccessLayerKinds)
         {

--- a/CDP4Dal/Composition/DalExportAttribute.cs
+++ b/CDP4Dal/Composition/DalExportAttribute.cs
@@ -25,9 +25,10 @@
 namespace CDP4Dal.Composition
 {
     using System;
+
     using CDP4Dal.DAL;
 
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
 
     using System.ComponentModel.Composition;
     

--- a/CDP4JsonFileDal/JsonFileDal.cs
+++ b/CDP4JsonFileDal/JsonFileDal.cs
@@ -24,7 +24,7 @@
 
 namespace CDP4JsonFileDal
 {
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
     using System.ComponentModel.Composition;
 #endif
 
@@ -60,7 +60,7 @@ namespace CDP4JsonFileDal
     /// Provides the Data Access Layer for file based import/export
     /// </summary>
     [DalExport("JSON File Based", "A file based JSON Data Access Layer", "1.1.0", DalType.File)]
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
     [PartCreationPolicy(CreationPolicy.NonShared)]
 #endif
     public class JsonFileDal : Dal

--- a/CDP4JsonSerializer/Helper/Utils.cs
+++ b/CDP4JsonSerializer/Helper/Utils.cs
@@ -52,10 +52,10 @@ namespace CDP4JsonSerializer.Helper
                 throw new ArgumentException("string can't be empty!");
             }
 
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
-            return string.Format("{0}{1}", input.First().ToString(CultureInfo.InvariantCulture).ToUpper(), input.Substring(1));
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+            return $"{input.First().ToString(CultureInfo.InvariantCulture).ToUpper()}{input.Substring(1)}";
 #else
-            return string.Format("{0}{1}", input.First().ToString().ToUpper(), input.Substring(1));
+            return $"{input.First().ToString().ToUpper()}{input.Substring(1)}";
 #endif
 
         }
@@ -78,10 +78,10 @@ namespace CDP4JsonSerializer.Helper
             {
                 throw new ArgumentException("string can't be empty!");
             }
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
-            return string.Format("{0}{1}", input.First().ToString(CultureInfo.InvariantCulture).ToLower(), input.Substring(1));
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+            return $"{input.First().ToString(CultureInfo.InvariantCulture).ToLower()}{input.Substring(1)}";
 #else
-            return string.Format("{0}{1}", input.First().ToString().ToLower(), input.Substring(1));
+            return $"{input.First().ToString().ToLower()}{input.Substring(1)}";
 #endif
         }
     }

--- a/CDP4ServicesDal/CdpServicesDal.cs
+++ b/CDP4ServicesDal/CdpServicesDal.cs
@@ -24,7 +24,7 @@
 
 namespace CDP4ServicesDal
 {
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
     using System.ComponentModel.Composition;
 #endif
 
@@ -63,7 +63,7 @@ namespace CDP4ServicesDal
     /// Annex C, REST API
     /// </summary>
     [DalExport("CDP4 Services", "A CDP4 Services Data Access Layer", "1.1.0", DalType.Web)]
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
     [PartCreationPolicy(CreationPolicy.NonShared)]
 #endif
     public class CdpServicesDal : Dal

--- a/CDP4WspDal/WSPDal.cs
+++ b/CDP4WspDal/WSPDal.cs
@@ -24,7 +24,7 @@
 
 namespace CDP4WspDal
 {
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
     using System.ComponentModel.Composition;
 #endif
 
@@ -60,7 +60,7 @@ namespace CDP4WspDal
     /// Provides the Data Access Layer for OCDT's WSP 
     /// </summary>
     [DalExport("OCDT WSP", "An OCDT WSP Data Access Layer", "1.0.0", DalType.Web)]
-#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472
+#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
     [PartCreationPolicy(CreationPolicy.NonShared)]
 #endif
     public class WspDal : Dal


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The net48 target was added to the csproj file, but the compiler conditional statements had not yet been updated, see sample below

```
#if NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
  some-code-goes-here
#endif
```

<!-- Thanks for contributing to CDP4-SDK! -->