### PR TITLE
[Add] hand-coded logic to determine whether an instance shall be serialized or not (handles PersonPermission and ParticipantPermission)

### DIFF
--- a/CDP4JsonSerializer.NetCore.Tests/CDP4JsonSerializer.NetCore.Tests.csproj
+++ b/CDP4JsonSerializer.NetCore.Tests/CDP4JsonSerializer.NetCore.Tests.csproj
@@ -28,7 +28,6 @@
   <ItemGroup>
     <Folder Include="Helper\" />
     <Folder Include="Deserializer\" />
-    <Folder Include="JsonConverter\" />
     <Folder Include="TestData\" />
   </ItemGroup>
 

--- a/CDP4JsonSerializer.NetCore.Tests/JsonConverter/ThingConverterExtensionsTestFixture.cs
+++ b/CDP4JsonSerializer.NetCore.Tests/JsonConverter/ThingConverterExtensionsTestFixture.cs
@@ -1,0 +1,97 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ThingConverterExtensionsTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4JsonSerializer.NetCore.Tests.JsonConverter
+{
+    using System;
+    
+    using CDP4Common.CommonData;
+    using CDP4Common.DTO;
+    using CDP4Common.MetaInfo;
+
+    using CDP4JsonSerializer.JsonConverter;
+    
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ThingConverterExtensions"/> class
+    /// </summary>
+    public class ThingConverterExtensionsTestFixture
+    {
+        private ThingConverterExtensions thingConverterExtensions;
+
+        private IMetaDataProvider metaDataProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.thingConverterExtensions = new ThingConverterExtensions();
+            this.metaDataProvider = new MetaDataProvider();
+        }
+
+        [Test]
+        public void Verify_that_PersonPermission_is_excluded_when_classkind_version_higher_than_requested_model_version()
+        {
+            var personPermission = new PersonPermission(Guid.NewGuid(), 1);
+            personPermission.ObjectClass = ClassKind.SampledFunctionParameterType;
+
+            Assert.That(this.thingConverterExtensions.AssertSerialization(personPermission, 
+                this.metaDataProvider, new Version(1, 0, 0)),
+                Is.False); 
+        }
+
+        [Test]
+        public void Verify_that_PersonPermission_is_included_when_classkind_version_eaual_or_lower_than_requested_model_version()
+        {
+            var personPermission = new PersonPermission(Guid.NewGuid(), 1);
+            personPermission.ObjectClass = ClassKind.SampledFunctionParameterType;
+
+            Assert.That(this.thingConverterExtensions.AssertSerialization(personPermission,
+                    this.metaDataProvider, new Version(1, 2, 0)),
+                Is.True);
+        }
+
+        [Test]
+        public void Verify_that_ParticipantPermission_is_excluded_when_classkind_version_higher_than_requested_model_version()
+        {
+            var participantPermission = new ParticipantPermission(Guid.NewGuid(), 1);
+            participantPermission.ObjectClass = ClassKind.ActionItem;
+
+            Assert.That(this.thingConverterExtensions.AssertSerialization(participantPermission,
+                    this.metaDataProvider, new Version(1, 0, 0)),
+                Is.False);
+        }
+
+        [Test]
+        public void Verify_that_ParticipantPermission_is_included_when_classkind_version_eaual_or_lower_than_requested_model_version()
+        {
+            var participantPermission = new ParticipantPermission(Guid.NewGuid(), 1);
+            participantPermission.ObjectClass = ClassKind.ActionItem;
+
+            Assert.That(this.thingConverterExtensions.AssertSerialization(participantPermission,
+                    this.metaDataProvider, new Version(1, 1, 0)),
+                Is.True);
+        }
+    }
+}

--- a/CDP4JsonSerializer.Tests/CDP4JsonSerializer.Tests.csproj
+++ b/CDP4JsonSerializer.Tests/CDP4JsonSerializer.Tests.csproj
@@ -29,7 +29,6 @@
   <ItemGroup>
     <Folder Include="Helper\" />
     <Folder Include="Deserializer\" />
-    <Folder Include="JsonConverter\" />
     <Folder Include="TestData\" />
   </ItemGroup>
 

--- a/CDP4JsonSerializer.Tests/JsonConverter/ThingConverterExtensionsTestFixture.cs
+++ b/CDP4JsonSerializer.Tests/JsonConverter/ThingConverterExtensionsTestFixture.cs
@@ -1,0 +1,97 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ThingConverterExtensionsTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4JsonSerializer.Tests.JsonConverter
+{
+    using System;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DTO;
+    using CDP4Common.MetaInfo;
+
+    using CDP4JsonSerializer.JsonConverter;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ThingConverterExtensions"/> class
+    /// </summary>
+    public class ThingConverterExtensionsTestFixture
+    {
+        private ThingConverterExtensions thingConverterExtensions;
+
+        private IMetaDataProvider metaDataProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.thingConverterExtensions = new ThingConverterExtensions();
+            this.metaDataProvider = new MetaDataProvider();
+        }
+
+        [Test]
+        public void Verify_that_PersonPermission_is_excluded_when_classkind_version_higher_than_requested_model_version()
+        {
+            var personPermission = new PersonPermission(Guid.NewGuid(), 1);
+            personPermission.ObjectClass = ClassKind.SampledFunctionParameterType;
+
+            Assert.That(this.thingConverterExtensions.AssertSerialization(personPermission,
+                    this.metaDataProvider, new Version(1, 0, 0)),
+                Is.False);
+        }
+
+        [Test]
+        public void Verify_that_PersonPermission_is_included_when_classkind_version_eaual_or_lower_than_requested_model_version()
+        {
+            var personPermission = new PersonPermission(Guid.NewGuid(), 1);
+            personPermission.ObjectClass = ClassKind.SampledFunctionParameterType;
+
+            Assert.That(this.thingConverterExtensions.AssertSerialization(personPermission,
+                    this.metaDataProvider, new Version(1, 2, 0)),
+                Is.True);
+        }
+
+        [Test]
+        public void Verify_that_ParticipantPermission_is_excluded_when_classkind_version_higher_than_requested_model_version()
+        {
+            var participantPermission = new ParticipantPermission(Guid.NewGuid(), 1);
+            participantPermission.ObjectClass = ClassKind.ActionItem;
+
+            Assert.That(this.thingConverterExtensions.AssertSerialization(participantPermission,
+                    this.metaDataProvider, new Version(1, 0, 0)),
+                Is.False);
+        }
+
+        [Test]
+        public void Verify_that_ParticipantPermission_is_included_when_classkind_version_eaual_or_lower_than_requested_model_version()
+        {
+            var participantPermission = new ParticipantPermission(Guid.NewGuid(), 1);
+            participantPermission.ObjectClass = ClassKind.ActionItem;
+
+            Assert.That(this.thingConverterExtensions.AssertSerialization(participantPermission,
+                    this.metaDataProvider, new Version(1, 1, 0)),
+                Is.True);
+        }
+    }
+}

--- a/CDP4JsonSerializer/JsonConverter/ThingCoverterExtensions.cs
+++ b/CDP4JsonSerializer/JsonConverter/ThingCoverterExtensions.cs
@@ -1,0 +1,78 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ThingConverterExtensions.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4JsonSerializer.JsonConverter
+{
+    using System;
+
+    using CDP4Common.DTO;
+    using CDP4Common.MetaInfo;
+
+    /// <summary>
+    /// The purpose of the <see cref="ThingConverterExtensions"/> is to implement extra business logic for hand-coded serialization to
+    /// decide to include or exclude classes from the serialization process
+    /// </summary>
+    public class ThingConverterExtensions
+    {
+        /// <summary>
+        /// Asserts whether an object shall be serialized or not
+        /// </summary>
+        /// <param name="value">
+        /// the <see cref="object"/> for which the serialization is to be asserted
+        /// </param>
+        /// <param name="metaDataProvider">
+        /// The <see cref="IMetaDataProvider"/> used to provide meta data
+        /// </param>
+        /// <param name="version">
+        /// The data model version to be used to determine whether a class shall be serialized or not
+        /// </param>
+        /// <returns>
+        /// returns true when the object shall be serialzed, false if not
+        /// </returns>
+        public bool AssertSerialization(object value, IMetaDataProvider metaDataProvider, Version version)
+        {
+            if (value is PersonPermission personPermission)
+            {
+                var classVersion = new Version(metaDataProvider.GetClassVersion(personPermission.ObjectClass.ToString()));
+
+                if (classVersion > version)
+                {
+                    return false;
+                }
+            }
+
+            if (value is ParticipantPermission participantPermission)
+            {
+                var classVersion = new Version(metaDataProvider.GetClassVersion(participantPermission.ObjectClass.ToString()));
+
+                if (classVersion > version)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/CDP4JsonSerializer/JsonConverter/ThingSerializer.cs
+++ b/CDP4JsonSerializer/JsonConverter/ThingSerializer.cs
@@ -1,5 +1,4 @@
-﻿#region Copyright
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ThingSerializer.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2019 RHEA System S.A.
 //
@@ -22,18 +21,19 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4JsonSerializer.JsonConverter
 {
     using System;
     using System.Collections.Generic;
+
     using CDP4Common.DTO;
     using CDP4Common.MetaInfo;
     using CDP4Common.Polyfills;
+
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
     using Newtonsoft.Json.Linq;
+
     using NLog;
 
     /// <summary>
@@ -52,6 +52,11 @@ namespace CDP4JsonSerializer.JsonConverter
         private readonly Version dataModelVersion;
 
         /// <summary>
+        /// The <see cref="ThingConverterExtensions"/> used to determine whether a class is to be serialized or not
+        /// </summary>
+        private readonly ThingConverterExtensions thingConverterExtensions;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ThingSerializer"/> class.
         /// </summary>
         /// <param name="metaInfoProvider">
@@ -64,6 +69,8 @@ namespace CDP4JsonSerializer.JsonConverter
         {
             this.MetaInfoProvider = metaInfoProvider;
             this.dataModelVersion = dataModelVersion;
+
+            this.thingConverterExtensions = new ThingConverterExtensions();
         }
 
         /// <summary>
@@ -120,6 +127,12 @@ namespace CDP4JsonSerializer.JsonConverter
             if (classVersion > this.dataModelVersion)
             {
                 // skip type serialization if the data version is larger then the request data model version
+                return;
+            }
+
+            if (!this.thingConverterExtensions.AssertSerialization(value, this.MetaInfoProvider, this.dataModelVersion))
+            {
+                // skip type serialization if the object is not to be included
                 return;
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
prototype solution to add custom logic to determine whether a instance shall be serialized or not. Implements PersonPermission and ParticipantPermission

see also issue https://github.com/RHEAGROUP/COMET-IME-Community-Edition/issues/931

<!-- Thanks for contributing to COMET-SDK! -->