### PR TITLE
Add Codex devcontainer for .NET 10 and .NET Framework 4.8

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install .NET 10 SDK and Mono tooling for .NET Framework 4.8 builds.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl gpg \
+    && curl -fsSL https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -o /tmp/packages-microsoft-prod.deb \
+    && dpkg -i /tmp/packages-microsoft-prod.deb \
+    && rm /tmp/packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends dotnet-sdk-10.0 mono-complete nuget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ensure Mono tools are discoverable in non-login shells.
+ENV PATH="/usr/lib/mono/msbuild/Current/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "comet-sdk-dotnet10-net48",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit"
+      ]
+    }
+  },
+  "postCreateCommand": "dotnet --info && msbuild -version",
+  "remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ The CDP4Web library is a C# library that provides helpful classes that facilitat
 
 The CDP4ServicesMessaging library is a C# library that provides abstractions over Rabbit MQ to support AMQP messaging
 
+## Development environment (.NET 10 + .NET Framework 4.8)
+
+This repository includes a dev container definition in `.devcontainer/` to provide a consistent Codex-ready development environment for:
+
+- .NET 10 SDK (for `net10.0` projects and tests)
+- Mono + MSBuild toolchain (for `net48` project builds)
+
+To use it in a compatible development environment, open the repository in the dev container and run:
+
+```bash
+dotnet --info
+msbuild -version
+```
+
+The repository also includes a `global.json` pinned to the .NET 10 SDK line.
+
 # License
 
 The libraries contained in the COMET-SDK Community Edition are provided to the community under the GNU Lesser General Public License. Because we make the software available with the LGPL, it can be used in both open source and proprietary software without being required to release the source code of your own components.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a reproducible, Codex/VS Code devcontainer that supports building and testing the repository's `net10.0` projects and `net48` projects from a single container image.
- Make it easier to run and debug tests and tooling in a consistent environment by pinning the SDK line and including Mono/MSBuild support for legacy .NET Framework builds.

### Description
- Add `.devcontainer/Dockerfile` based on `mcr.microsoft.com/devcontainers/base:ubuntu-24.04` that installs `dotnet-sdk-10.0`, `mono-complete`, and `nuget`, and updates `PATH` so Mono/MSBuild is discoverable in shells.
- Add `.devcontainer/devcontainer.json` defining a devcontainer named `comet-sdk-dotnet10-net48` with recommended C# extensions and a `postCreateCommand` that runs `dotnet --info && msbuild -version`.
- Add `global.json` pinned to the .NET 10 SDK line (`10.0.100`) with `rollForward` and `allowPrerelease` settings to prefer the .NET 10 feature band.
- Update `README.md` with a new "Development environment (.NET 10 + .NET Framework 4.8)" section that documents the devcontainer and quick verification commands (`dotnet --info`, `msbuild -version`).

### Testing
- Ran `python -m json.tool .devcontainer/devcontainer.json` and `python -m json.tool global.json` to validate JSON syntax, and both validations succeeded.
- Attempted to probe external Microsoft docs with `curl` to validate install guidance, but the outbound request failed with HTTP 403 in this environment so remote verification could not complete.
- Could not run `dotnet --info` or `msbuild -version` locally here because the host environment lacks the SDK; those are configured to run automatically inside the devcontainer via `postCreateCommand`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c03c80e7c8326adc999bd79af07e5)