### PR TITLE
[Update] RabbitMQ.Client to 7.2.1 and migrate CDP4ServicesMessaging to async API

### DIFF
--- a/CDP4ServicesMessaging.Tests/Services/Messaging/BaseClientTestFixture.cs
+++ b/CDP4ServicesMessaging.Tests/Services/Messaging/BaseClientTestFixture.cs
@@ -24,6 +24,8 @@
 
 namespace CDP4ServicesMessaging.Tests.Services.Messaging
 {
+    using System.Threading;
+
     using CDP4ServicesMessaging.Serializers.Json;
     using CDP4ServicesMessaging.Services.Messaging;
 
@@ -33,13 +35,13 @@ namespace CDP4ServicesMessaging.Tests.Services.Messaging
     using Moq;
 
     using RabbitMQ.Client;
-    
+
     public class BaseClientTestFixture<T> where T : MessageClientService
     {
         protected Mock<ILogger<T>> Logger;
         protected Mock<IConfiguration> Configuration;
         protected Mock<IConnection> Connection;
-        protected Mock<IModel> Model;
+        protected Mock<IChannel> Model;
         protected Mock<IConnectionFactory> ConnectionFactory;
         protected Mock<IConfigurationSection> MessageBrokerSettings;
         protected T Service;
@@ -52,7 +54,7 @@ namespace CDP4ServicesMessaging.Tests.Services.Messaging
             this.Logger = new Mock<ILogger<T>>();
 
             this.Connection = new Mock<IConnection>();
-            this.Model = new Mock<IModel>();
+            this.Model = new Mock<IChannel>();
             this.ConnectionFactory = new Mock<IConnectionFactory>();
 
             var value = new Mock<IConfigurationSection>(MockBehavior.Loose);
@@ -67,14 +69,14 @@ namespace CDP4ServicesMessaging.Tests.Services.Messaging
                 .Returns(this.MessageBrokerSettings.Object);
 
             this.Serializer = new Mock<ICdp4MessageSerializer>();
-            
+
             this.ConnectionFactory
-                .Setup(x => x.CreateConnection())
-                .Returns(this.Connection.Object);
+                .Setup(x => x.CreateConnectionAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(this.Connection.Object);
 
             this.Connection
-                .Setup(x => x.CreateModel())
-                .Returns(this.Model.Object);
+                .Setup(x => x.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(this.Model.Object);
         }
     }
 }

--- a/CDP4ServicesMessaging.Tests/Services/Messaging/MessageClientServiceTestFixture.cs
+++ b/CDP4ServicesMessaging.Tests/Services/Messaging/MessageClientServiceTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------------------------------------
 // <copyright file="MessageClientServiceTestFixture.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2023 Starion Group S.A.
 //
@@ -25,14 +25,15 @@
 namespace CDP4ServicesMessaging.Tests.Services.Messaging
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
 
     using Moq;
 
     using NUnit.Framework;
 
-    using RabbitMQ.Client.Events;
     using RabbitMQ.Client;
+    using RabbitMQ.Client.Events;
 
     [TestFixture]
     public class MessageClientServiceTestFixture : BaseClientTestFixture<TestMessageClient>
@@ -52,42 +53,42 @@ namespace CDP4ServicesMessaging.Tests.Services.Messaging
             Assert.Multiple(() =>
             {
                 Assert.That(() => this.Service.Connect(), Throws.Exception.TypeOf<TimeoutException>());
-                this.ConnectionFactory.Verify(x => x.CreateConnection(), Times.Exactly(10));
-                this.Connection.Verify(x => x.CreateModel(), Times.Exactly(10));
+                this.ConnectionFactory.Verify(x => x.CreateConnectionAsync(It.IsAny<CancellationToken>()), Times.Exactly(10));
+                this.Connection.Verify(x => x.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(10));
             });
         }
-        
+
         [Test]
         public void Verify_that_Retry_Works()
         {
-            this.Model.SetupAdd(m => m.ModelShutdown += (sender, args) => { });
-            this.Connection.SetupAdd(m => m.ConnectionBlocked += (sender, args) => { });
-            this.Connection.SetupAdd(m => m.ConnectionUnblocked += (sender, args) => { });
-            this.Connection.SetupAdd(m => m.ConnectionShutdown += (sender, args) => { });
-            
+            this.Model.SetupAdd(m => m.ChannelShutdownAsync += (sender, args) => Task.CompletedTask);
+            this.Connection.SetupAdd(m => m.ConnectionBlockedAsync += (sender, args) => Task.CompletedTask);
+            this.Connection.SetupAdd(m => m.ConnectionUnblockedAsync += (sender, args) => Task.CompletedTask);
+            this.Connection.SetupAdd(m => m.ConnectionShutdownAsync += (sender, args) => Task.CompletedTask);
+
             this.Service.ThrowErrorOnRegisterListenersAndDeclareQueues = true;
 
             Assert.Multiple(() =>
             {
                 Assert.That(() => this.Service.Connect(), Throws.Exception.TypeOf<TimeoutException>());
 
-                this.Model.VerifyAdd(m => m.ModelShutdown += It.IsAny<EventHandler<ShutdownEventArgs>>(), Times.Exactly(5));
-                this.Connection.VerifyAdd(m => m.ConnectionBlocked += It.IsAny<EventHandler<ConnectionBlockedEventArgs>>(), Times.Exactly(5));
-                this.Connection.VerifyAdd(m => m.ConnectionUnblocked += It.IsAny<EventHandler<EventArgs>>(), Times.Exactly(5));
-                this.Connection.VerifyAdd(m => m.ConnectionShutdown += It.IsAny<EventHandler<ShutdownEventArgs>>(), Times.Exactly(5));
-            
+                this.Model.VerifyAdd(m => m.ChannelShutdownAsync += It.IsAny<AsyncEventHandler<ShutdownEventArgs>>(), Times.Exactly(5));
+                this.Connection.VerifyAdd(m => m.ConnectionBlockedAsync += It.IsAny<AsyncEventHandler<ConnectionBlockedEventArgs>>(), Times.Exactly(5));
+                this.Connection.VerifyAdd(m => m.ConnectionUnblockedAsync += It.IsAny<AsyncEventHandler<AsyncEventArgs>>(), Times.Exactly(5));
+                this.Connection.VerifyAdd(m => m.ConnectionShutdownAsync += It.IsAny<AsyncEventHandler<ShutdownEventArgs>>(), Times.Exactly(5));
+
                 this.Model.Verify(x => x.IsOpen, Times.Exactly(4));
 
                 this.ConnectionFactory
-                    .Verify(x => x.CreateConnection(), Times.Exactly(5));
+                    .Verify(x => x.CreateConnectionAsync(It.IsAny<CancellationToken>()), Times.Exactly(5));
 
                 this.Connection
-                    .Verify(x => x.CreateModel(), Times.Exactly(5));
+                    .Verify(x => x.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(5));
 
-                this.Model.VerifyRemove(m => m.ModelShutdown -= It.IsAny<EventHandler<ShutdownEventArgs>>(), Times.Exactly(6));
-                this.Connection.VerifyRemove(m => m.ConnectionBlocked -= It.IsAny<EventHandler<ConnectionBlockedEventArgs>>(), Times.Exactly(6));
-                this.Connection.VerifyRemove(m => m.ConnectionUnblocked -= It.IsAny<EventHandler<EventArgs>>(), Times.Exactly(6));
-                this.Connection.VerifyRemove(m => m.ConnectionShutdown -= It.IsAny<EventHandler<ShutdownEventArgs>>(), Times.Exactly(6));
+                this.Model.VerifyRemove(m => m.ChannelShutdownAsync -= It.IsAny<AsyncEventHandler<ShutdownEventArgs>>(), Times.Exactly(6));
+                this.Connection.VerifyRemove(m => m.ConnectionBlockedAsync -= It.IsAny<AsyncEventHandler<ConnectionBlockedEventArgs>>(), Times.Exactly(6));
+                this.Connection.VerifyRemove(m => m.ConnectionUnblockedAsync -= It.IsAny<AsyncEventHandler<AsyncEventArgs>>(), Times.Exactly(6));
+                this.Connection.VerifyRemove(m => m.ConnectionShutdownAsync -= It.IsAny<AsyncEventHandler<ShutdownEventArgs>>(), Times.Exactly(6));
             });
         }
     }

--- a/CDP4ServicesMessaging.Tests/Services/TestMessageClient.cs
+++ b/CDP4ServicesMessaging.Tests/Services/TestMessageClient.cs
@@ -47,7 +47,7 @@ namespace CDP4ServicesMessaging.Tests.Services
             this.ConnectionFactory = connectionFactory;
         }
 
-        public async Task<IModel> Connect()
+        public async Task<IChannel> Connect()
         {
             try
             {
@@ -64,7 +64,7 @@ namespace CDP4ServicesMessaging.Tests.Services
             return default;
         }
 
-        protected override void AfterChannelCreation()
+        protected override Task AfterChannelCreationAsync()
         {
             if (!this.failed && this.ThrowErrorOnRegisterListenersAndDeclareQueues)
             {
@@ -77,6 +77,8 @@ namespace CDP4ServicesMessaging.Tests.Services
 
                 throw new NotImplementedException();
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/CDP4ServicesMessaging.Tests/Services/ThingMessaging/ThingMessageConsumerTestFixture.cs
+++ b/CDP4ServicesMessaging.Tests/Services/ThingMessaging/ThingMessageConsumerTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------------------------------------
 // <copyright file="ThingMessageConsumerTestFixture.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2023 Starion Group S.A.
 //
@@ -24,6 +24,8 @@
 
 namespace CDP4ServicesMessaging.Tests.Services.ThingMessaging
 {
+    using System.Threading;
+
     using CDP4ServicesMessaging.Messages;
     using CDP4ServicesMessaging.Services.ThingMessaging;
     using CDP4ServicesMessaging.Tests.Services.Messaging;
@@ -48,11 +50,11 @@ namespace CDP4ServicesMessaging.Tests.Services.ThingMessaging
         public async Task VerifyAddListener()
         {
             this.Model.Setup(x => x.IsOpen).Returns(true);
-            
-            this.Model.Setup(x => x.QueueDeclare(
-                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IDictionary<string, object>>()))
-                .Returns(new QueueDeclareOk("", 1, 1));
-            
+
+            this.Model.Setup(x => x.QueueDeclareAsync(
+                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new QueueDeclareOk("", 1, 1));
+
             var messageReceived = new List<ThingsChangedMessage>();
 
             Assert.Multiple(() =>
@@ -70,12 +72,12 @@ namespace CDP4ServicesMessaging.Tests.Services.ThingMessaging
             {
                 Assert.That(() => this.Service.AddListener(x => messageReceived.Add(x)), Throws.Exception.TypeOf<TimeoutException>());
                 this.Model.Verify(x => x.IsOpen, Times.Exactly(8));
-            
-                this.Model.Verify(x => x.QueueDeclare(
-                        It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IDictionary<string, object>>()), 
+
+                this.Model.Verify(x => x.QueueDeclareAsync(
+                        It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
                     Times.Exactly(2));
 
-                this.Model.Verify(x => x.ExchangeDeclare("ThingsChangedMessage", "fanout", true, false, null),
+                this.Model.Verify(x => x.ExchangeDeclareAsync("ThingsChangedMessage", "fanout", true, false, null, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
                     Times.Exactly(2));
             });
         }
@@ -85,17 +87,17 @@ namespace CDP4ServicesMessaging.Tests.Services.ThingMessaging
         {
             this.Model.Setup(x => x.IsOpen).Returns(true);
 
-            this.Model.Setup(x => x.QueueDeclare(
-                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IDictionary<string, object>>()))
-                .Returns(new QueueDeclareOk("", 1, 1));
-            
+            this.Model.Setup(x => x.QueueDeclareAsync(
+                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new QueueDeclareOk("", 1, 1));
+
             var messageReceived = new List<ThingsChangedMessage>();
 
             Assert.Multiple(() =>
             {
                 Assert.That(async () => (await this.Service.Listen())
                     .Subscribe(x => messageReceived.Add(x), x => throw x), Throws.Nothing);
-            
+
                 Assert.That(messageReceived, Is.Empty);
             });
 
@@ -111,7 +113,7 @@ namespace CDP4ServicesMessaging.Tests.Services.ThingMessaging
 
                 this.Model.Verify(x => x.IsOpen, Times.AtLeast(10));
 
-                this.Model.Verify(x => x.ExchangeDeclare("ThingsChangedMessage", "fanout", true, false, null),
+                this.Model.Verify(x => x.ExchangeDeclareAsync("ThingsChangedMessage", "fanout", true, false, null, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
                     Times.AtLeast(2));
             });
         }

--- a/CDP4ServicesMessaging.Tests/Services/ThingMessaging/ThingMessageProducerTestFixture.cs
+++ b/CDP4ServicesMessaging.Tests/Services/ThingMessaging/ThingMessageProducerTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------------------------------------
 // <copyright file="ThingMessageProducerTestFixture.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2023 Starion Group S.A.
 //
@@ -24,6 +24,8 @@
 
 namespace CDP4ServicesMessaging.Tests.Services.ThingMessaging
 {
+    using System.Threading;
+
     using CDP4Common.DTO;
 
     using CDP4ServicesMessaging.Messages;
@@ -51,29 +53,26 @@ namespace CDP4ServicesMessaging.Tests.Services.ThingMessaging
         {
             this.Model.Setup(x => x.IsOpen).Returns(true);
 
-            this.Model.Setup(x => x.QueueDeclare(
-                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IDictionary<string, object>>()))
-                .Returns(new QueueDeclareOk("", 1, 1));
-
-            var properties = new Mock<IBasicProperties>();
-            this.Model.Setup(x => x.CreateBasicProperties()).Returns(properties.Object);
+            this.Model.Setup(x => x.QueueDeclareAsync(
+                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new QueueDeclareOk("", 1, 1));
 
             var message = new ThingsChangedMessage()
             {
                 ChangedThings = { new ElementDefinition() { Name = nameof(ElementDefinition) }, new EngineeringModel(), new Parameter() { } },
                 ActorId = Guid.NewGuid(),
             };
-            
+
             await this.Service.Push(message);
             await this.Service.PushParallel(message);
 
             Assert.Multiple(() =>
             {
-                this.Model.Verify(x => x.BasicPublish(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(),It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()),
+                this.Model.Verify(x => x.BasicPublishAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<BasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()),
                     Times.Exactly(2));
 
                 this.Serializer.Verify(x => x.Serialize(message), Times.Exactly(2));
-                this.Model.Verify(x => x.ExchangeDeclare("ThingsChangedMessage", "fanout", true, false, null), Times.Exactly(2));
+                this.Model.Verify(x => x.ExchangeDeclareAsync("ThingsChangedMessage", "fanout", true, false, null, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
             });
         }
     }

--- a/CDP4ServicesMessaging/CDP4ServicesMessaging.csproj
+++ b/CDP4ServicesMessaging/CDP4ServicesMessaging.csproj
@@ -57,7 +57,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
         <PackageReference Include="Polly" Version="8.6.6" />
-        <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+        <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
     </ItemGroup>
 
     <ItemGroup Label="build-only dependencies">

--- a/CDP4ServicesMessaging/Services/Messaging/Interfaces/IMessageClientService.cs
+++ b/CDP4ServicesMessaging/Services/Messaging/Interfaces/IMessageClientService.cs
@@ -52,11 +52,11 @@ namespace CDP4ServicesMessaging.Services.Messaging.Interfaces
         /// Adds a listener to the specified queue
         /// </summary>
         /// <param name="queueName">The <see cref="string"/> queue name</param>
-        /// <param name="onReceive">The <see cref="EventHandler"/></param>
+        /// <param name="onReceive">The <see cref="AsyncEventHandler{BasicDeliverEventArgs}"/></param>
         /// <param name="exchangeType">The string exchange type It can be any value from <see cref="ExchangeType"/>, default value is <see cref="ExchangeType.Default"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/></param>
         /// <return>A <see cref="Task"/> of <see cref="IDisposable"/></return>
-        Task<IDisposable> AddListener(string queueName, EventHandler<BasicDeliverEventArgs> onReceive, ExchangeType exchangeType = ExchangeType.Default, CancellationToken cancellationToken = default);
+        Task<IDisposable> AddListener(string queueName, AsyncEventHandler<BasicDeliverEventArgs> onReceive, ExchangeType exchangeType = ExchangeType.Default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Pushes the specified <paramref name="message"/> in parallel, executing the operation in a fire-and-forget manner to the specified <paramref name="messageQueue"/>

--- a/CDP4ServicesMessaging/Services/Messaging/MessageClientBaseService.cs
+++ b/CDP4ServicesMessaging/Services/Messaging/MessageClientBaseService.cs
@@ -26,17 +26,17 @@ namespace CDP4ServicesMessaging.Services.Messaging
 {
     using System;
     using System.Threading;
+    using System.Threading.Tasks;
 
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Configuration;
 
     using RabbitMQ.Client;
+    using RabbitMQ.Client.Events;
 
     using CDP4ServicesMessaging.Services.Messaging.Interfaces;
 
     using Polly;
-
-    using System.Threading.Tasks;
 
     /// <summary>
     /// The <see cref="MessageClientBaseService"/> is the base RabbitMQ client
@@ -44,7 +44,7 @@ namespace CDP4ServicesMessaging.Services.Messaging
     public abstract class MessageClientBaseService : IMessageQueueClientBaseService
     {
         /// <summary>
-        /// Gets or sets the <see cref="ILogger"/> 
+        /// Gets or sets the <see cref="ILogger"/>
         /// </summary>
         public ILogger<MessageClientBaseService> Logger { get; }
 
@@ -52,7 +52,7 @@ namespace CDP4ServicesMessaging.Services.Messaging
         /// The <see cref="IConnectionFactory"/> for this client
         /// </summary>
         internal IConnectionFactory ConnectionFactory { get; set; }
-        
+
         /// <summary>
         /// The number of times the connection process can be attempted
         /// </summary>
@@ -62,7 +62,7 @@ namespace CDP4ServicesMessaging.Services.Messaging
         /// The time span in seconds between connection attempts.
         /// </summary>
         private int timeSpanBetweenAttempts = 1;
-        
+
         /// <summary>
         /// The <see cref="IConfiguration"/>
         /// </summary>
@@ -74,9 +74,9 @@ namespace CDP4ServicesMessaging.Services.Messaging
         private IConnection connection;
 
         /// <summary>
-        /// The per thread <see cref="IModel"/>
+        /// The per thread <see cref="IChannel"/>
         /// </summary>
-        private readonly ThreadLocal<IModel> threadLocalChannel = new ();
+        private readonly ThreadLocal<IChannel> threadLocalChannel = new ();
 
         /// <summary>
         /// Initializes a new <see cref="MessageClientBaseService"/>
@@ -118,15 +118,15 @@ namespace CDP4ServicesMessaging.Services.Messaging
         /// <returns>
         /// The integer configuration value associated with the specified key, or the default value if the key is not found or the value cannot be parsed as an integer.
         /// </returns>
-        private int GetIntConfig(string configKey, int defaultValue) => 
+        private int GetIntConfig(string configKey, int defaultValue) =>
             int.TryParse(this.configuration[configKey], out var configValue) ? configValue : defaultValue;
 
         /// <summary>
-        /// Establishes a connection to the RabbitMQ server and returns an asynchronous <see cref="IModel"/> Channel.
+        /// Establishes a connection to the RabbitMQ server and returns an asynchronous <see cref="IChannel"/>.
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> for task cancellation.</param>
-        /// <returns>An asynchronous task returning a <see cref="IModel"/> Channel.</returns>
-        protected async Task<IModel> GetChannelAsync(CancellationToken cancellationToken = default)
+        /// <returns>An asynchronous task returning an <see cref="IChannel"/>.</returns>
+        protected async Task<IChannel> GetChannelAsync(CancellationToken cancellationToken = default)
         {
             var currentThreadChannel = this.threadLocalChannel.Value;
 
@@ -150,8 +150,8 @@ namespace CDP4ServicesMessaging.Services.Messaging
                 })
                 .Or<Exception>(x => this.HandleConnectionFailed(ref attemptNumber, x))
                 .WaitAndRetryAsync(this.maxConnectionRetryAttempts, _ => TimeSpan.FromSeconds(this.timeSpanBetweenAttempts));
-            
-            var result = await policy.ExecuteAndCaptureAsync(x => this.GetChannel(), cancellationToken);
+
+            var result = await policy.ExecuteAndCaptureAsync(ct => this.GetChannel(ct), cancellationToken);
 
             if (result.Outcome is not OutcomeType.Successful)
             {
@@ -161,28 +161,29 @@ namespace CDP4ServicesMessaging.Services.Messaging
 
             return this.threadLocalChannel.Value;
         }
-        
+
         /// <summary>
         /// Creates a RabbitMQ connection and a channel, establishing a connection to the server.
         /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> for task cancellation.</param>
         /// <returns>An asynchronous task returning a value indicating whether the channel is open.</returns>
-        private Task<bool> GetChannel()
+        private async Task<bool> GetChannel(CancellationToken cancellationToken)
         {
-            this.connection = this.ConnectionFactory.CreateConnection();
+            this.connection = await this.ConnectionFactory.CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
 
-            this.connection.ConnectionBlocked += this.OnConnectionBlocked;
-            this.connection.ConnectionShutdown += this.OnConnectionShutdown;
-            this.connection.ConnectionUnblocked += this.OnConnectionUnblocked;
+            this.connection.ConnectionBlockedAsync += this.OnConnectionBlockedAsync;
+            this.connection.ConnectionShutdownAsync += this.OnConnectionShutdownAsync;
+            this.connection.ConnectionUnblockedAsync += this.OnConnectionUnblockedAsync;
 
-            var newChannel = this.connection.CreateModel();
+            var newChannel = await this.connection.CreateChannelAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            newChannel.ModelShutdown += this.OnChannelModelShutdown;
+            newChannel.ChannelShutdownAsync += this.OnChannelShutdownAsync;
 
             this.threadLocalChannel.Value = newChannel;
 
-            this.AfterChannelCreation();
+            await this.AfterChannelCreationAsync().ConfigureAwait(false);
 
-            return Task.FromResult(newChannel is { IsOpen: true });
+            return newChannel is { IsOpen: true };
         }
 
         /// <summary>
@@ -194,14 +195,14 @@ namespace CDP4ServicesMessaging.Services.Messaging
         {
             if (this.connection != null)
             {
-                this.connection.ConnectionBlocked -= this.OnConnectionBlocked;
-                this.connection.ConnectionShutdown -= this.OnConnectionShutdown;
-                this.connection.ConnectionUnblocked -= this.OnConnectionUnblocked;
+                this.connection.ConnectionBlockedAsync -= this.OnConnectionBlockedAsync;
+                this.connection.ConnectionShutdownAsync -= this.OnConnectionShutdownAsync;
+                this.connection.ConnectionUnblockedAsync -= this.OnConnectionUnblockedAsync;
             }
 
             if (this.threadLocalChannel.Value != null)
             {
-                this.threadLocalChannel.Value.ModelShutdown -= this.OnChannelModelShutdown;
+                this.threadLocalChannel.Value.ChannelShutdownAsync -= this.OnChannelShutdownAsync;
             }
 
             var message = $"The message client failed to connect to {(this.ConnectionFactory is ConnectionFactory connectionFactory ? connectionFactory.Endpoint : "Unknown")}. {(exception?.Message ?? "")}";
@@ -218,20 +219,23 @@ namespace CDP4ServicesMessaging.Services.Messaging
         }
 
         /// <summary>
-        /// Logic to run after the <see cref="IModel"/> has been created
+        /// Logic to run after the <see cref="IChannel"/> has been created
         /// </summary>
-        protected virtual void AfterChannelCreation()
+        /// <returns>An awaitable <see cref="Task"/></returns>
+        protected virtual Task AfterChannelCreationAsync()
         {
+            return Task.CompletedTask;
         }
 
         /// <summary>
-        /// Model shutdown event handler.
+        /// Channel shutdown event handler.
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The arguments.</param>
-        protected virtual void OnChannelModelShutdown(object sender, ShutdownEventArgs e)
+        protected virtual Task OnChannelShutdownAsync(object sender, ShutdownEventArgs e)
         {
-            this.Logger.LogWarning("Message broker channel model has shut down. {Cause}", e.Cause);
+            this.Logger.LogWarning("Message broker channel has shut down. {Cause}", e.Cause);
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -239,9 +243,10 @@ namespace CDP4ServicesMessaging.Services.Messaging
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The arguments.</param>
-        protected virtual void OnConnectionUnblocked(object sender, EventArgs e)
+        protected virtual Task OnConnectionUnblockedAsync(object sender, AsyncEventArgs e)
         {
-            this.Logger.LogInformation($"Message broker connection unblocked.");
+            this.Logger.LogInformation("Message broker connection unblocked.");
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -249,9 +254,10 @@ namespace CDP4ServicesMessaging.Services.Messaging
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The arguments.</param>
-        protected virtual void OnConnectionShutdown(object sender, ShutdownEventArgs e)
+        protected virtual Task OnConnectionShutdownAsync(object sender, ShutdownEventArgs e)
         {
             this.Logger.LogWarning("Message broker connection shutdown. {Cause}", e.Cause);
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -259,9 +265,10 @@ namespace CDP4ServicesMessaging.Services.Messaging
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The arguments.</param>
-        protected virtual void OnConnectionBlocked(object sender, RabbitMQ.Client.Events.ConnectionBlockedEventArgs e)
+        protected virtual Task OnConnectionBlockedAsync(object sender, ConnectionBlockedEventArgs e)
         {
             this.Logger.LogWarning("Message broker connection blocked. {Reason}", e.Reason);
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -277,15 +284,15 @@ namespace CDP4ServicesMessaging.Services.Messaging
 
             if (this.connection != null)
             {
-                this.connection.ConnectionBlocked -= this.OnConnectionBlocked;
-                this.connection.ConnectionShutdown -= this.OnConnectionShutdown;
-                this.connection.ConnectionUnblocked -= this.OnConnectionUnblocked;
+                this.connection.ConnectionBlockedAsync -= this.OnConnectionBlockedAsync;
+                this.connection.ConnectionShutdownAsync -= this.OnConnectionShutdownAsync;
+                this.connection.ConnectionUnblockedAsync -= this.OnConnectionUnblockedAsync;
                 this.connection.Dispose();
             }
 
-            if (this.threadLocalChannel.IsValueCreated)
+            if (this.threadLocalChannel.IsValueCreated && this.threadLocalChannel.Value != null)
             {
-                this.threadLocalChannel.Value.ModelShutdown -= this.OnChannelModelShutdown;
+                this.threadLocalChannel.Value.ChannelShutdownAsync -= this.OnChannelShutdownAsync;
                 this.threadLocalChannel.Value.Dispose();
             }
         }

--- a/CDP4ServicesMessaging/Services/Messaging/MessageClientService.cs
+++ b/CDP4ServicesMessaging/Services/Messaging/MessageClientService.cs
@@ -41,8 +41,6 @@ namespace CDP4ServicesMessaging.Services.Messaging
     using RabbitMQ.Client;
     using RabbitMQ.Client.Events;
 
-    using IModel = RabbitMQ.Client.IModel;
-
     /// <summary>
     /// The <see cref="MessageClientService"/> is the main implementation for the RabbitMQ client
     /// </summary>
@@ -52,7 +50,7 @@ namespace CDP4ServicesMessaging.Services.Messaging
         /// The <see cref="IMessageSerializer"/>
         /// </summary>
         protected readonly IMessageSerializer Serializer;
-        
+
         /// <summary>
         /// Initializes a new <see cref="MessageClientBaseService"/>
         /// </summary>
@@ -76,9 +74,9 @@ namespace CDP4ServicesMessaging.Services.Messaging
         {
             var channel = await this.GetChannelAsync(cancellationToken);
 
-            return Observable.Create<TMessage>(observer =>
+            return Observable.Create<TMessage>(async observer =>
             {
-                var disposables = this.InitializeListener(observer, channel, queueName, exchangeType);
+                var disposables = await this.InitializeListenerAsync(observer, channel, queueName, exchangeType, cancellationToken);
 
                 return Disposable.Create(() => disposables.Dispose());
             });
@@ -92,30 +90,41 @@ namespace CDP4ServicesMessaging.Services.Messaging
         /// <param name="channel">The RabbitMQ channel.</param>
         /// <param name="queueName">The name of the queue to listen on.</param>
         /// <param name="exchangeType">The exchange type. Default is <see cref="ExchangeType.Default"/>.</param>
+        /// <param name="cancellationToken">Cancellation token for the asynchronous operation.</param>
         /// <returns>A disposable to clean up resources.</returns>
-        private IDisposable InitializeListener<TMessage>(IObserver<TMessage> observer, IModel channel, string queueName, ExchangeType exchangeType) where TMessage : class
+        private async Task<IDisposable> InitializeListenerAsync<TMessage>(IObserver<TMessage> observer, IChannel channel, string queueName, ExchangeType exchangeType, CancellationToken cancellationToken) where TMessage : class
         {
-            EventingBasicConsumer consumer = null;
+            AsyncEventingBasicConsumer consumer = null;
 
-            void ConsumerOnReceived(object _, BasicDeliverEventArgs m) =>
+            Task ConsumerOnReceivedAsync(object _, BasicDeliverEventArgs m)
+            {
                 observer.OnNext(this.Serializer.Deserialize<TMessage>(m.Body));
+                return Task.CompletedTask;
+            }
 
-            void ConsumerOnShutdown(object _, ShutdownEventArgs a) =>
+            Task ConsumerOnShutdownAsync(object _, ShutdownEventArgs a)
+            {
                 observer.OnError(new OperationCanceledException($"The channel has shutdown [Reply: {a.ReplyText}, AMQPcode: {a.ReplyCode}]"));
+                return Task.CompletedTask;
+            }
 
-            void ChannelOnCallbackException(object _, CallbackExceptionEventArgs m) =>
+            Task ChannelOnCallbackExceptionAsync(object _, CallbackExceptionEventArgs m)
+            {
                 observer.OnError(m.Exception);
+                return Task.CompletedTask;
+            }
 
             try
             {
-                channel.CallbackException += ChannelOnCallbackException;
+                channel.CallbackExceptionAsync += ChannelOnCallbackExceptionAsync;
 
-                consumer = new EventingBasicConsumer(channel);
+                consumer = new AsyncEventingBasicConsumer(channel);
 
-                consumer.Received += ConsumerOnReceived;
-                consumer.Shutdown += ConsumerOnShutdown;
+                consumer.ReceivedAsync += ConsumerOnReceivedAsync;
+                consumer.ShutdownAsync += ConsumerOnShutdownAsync;
 
-                channel.BasicConsume(this.EnsureQueueAndExchangeAreDeclared(queueName, channel, exchangeType), true, consumer);
+                var resolvedQueueName = await this.EnsureQueueAndExchangeAreDeclaredAsync(queueName, channel, exchangeType, cancellationToken: cancellationToken);
+                await channel.BasicConsumeAsync(resolvedQueueName, true, consumer, cancellationToken);
             }
             catch (Exception exception)
             {
@@ -124,41 +133,41 @@ namespace CDP4ServicesMessaging.Services.Messaging
 
             return Disposable.Create(() =>
             {
-                channel.CallbackException -= ChannelOnCallbackException; 
-                
+                channel.CallbackExceptionAsync -= ChannelOnCallbackExceptionAsync;
+
                 if (consumer == null)
                 {
                     return;
                 }
 
-                consumer.Received -= ConsumerOnReceived;
-                consumer.Shutdown -= ConsumerOnShutdown;
+                consumer.ReceivedAsync -= ConsumerOnReceivedAsync;
+                consumer.ShutdownAsync -= ConsumerOnShutdownAsync;
             });
         }
-        
+
         /// <summary>
         /// Adds a listener to the specified queue
         /// </summary>
         /// <param name="queueName">The <see cref="string"/> queue name</param>
-        /// <param name="onReceive">The <see cref="EventHandler"/></param>
+        /// <param name="onReceive">The <see cref="AsyncEventHandler{BasicDeliverEventArgs}"/></param>
         /// <param name="exchangeType">The string exchange type It can be any value from <see cref="ExchangeType"/>, default value is <see cref="ExchangeType.Default"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/></param>
         /// <return>A <see cref="Task"/> of <see cref="IDisposable"/></return>
-        public async Task<IDisposable> AddListener(string queueName, EventHandler<BasicDeliverEventArgs> onReceive, ExchangeType exchangeType = ExchangeType.Default, CancellationToken cancellationToken = default)
+        public async Task<IDisposable> AddListener(string queueName, AsyncEventHandler<BasicDeliverEventArgs> onReceive, ExchangeType exchangeType = ExchangeType.Default, CancellationToken cancellationToken = default)
         {
-            IModel channel = default;
-            EventingBasicConsumer consumer = default;
+            IChannel channel = default;
+            AsyncEventingBasicConsumer consumer = default;
 
             try
             {
                 channel = await this.GetChannelAsync(cancellationToken);
 
-                this.EnsureQueueAndExchangeAreDeclared(queueName, channel, exchangeType);
+                await this.EnsureQueueAndExchangeAreDeclaredAsync(queueName, channel, exchangeType, cancellationToken: cancellationToken);
 
-                consumer = new EventingBasicConsumer(channel);
-                consumer.Received += onReceive;
+                consumer = new AsyncEventingBasicConsumer(channel);
+                consumer.ReceivedAsync += onReceive;
 
-                channel.BasicConsume(queueName, true, consumer);
+                await channel.BasicConsumeAsync(queueName, true, consumer, cancellationToken);
             }
             catch (TimeoutException)
             {
@@ -172,7 +181,7 @@ namespace CDP4ServicesMessaging.Services.Messaging
             {
                 if (consumer != null)
                 {
-                    consumer.Received -= onReceive;
+                    consumer.ReceivedAsync -= onReceive;
                 }
             }
 
@@ -229,6 +238,7 @@ namespace CDP4ServicesMessaging.Services.Messaging
         /// <param name="messageQueue">The <see cref="string"/> queue name on which to send to the <paramref name="messages"/></param>
         /// <param name="messages">The collection of <typeparamref name="TMessage"/> to push</param>
         /// <param name="exchangeType">The string exchange type It can be any value from <see cref="ExchangeType"/>, default value is <see cref="ExchangeType.Default"/></param>
+        /// <param name="cancellationToken">A possible <see cref="CancellationToken"/></param>
         /// <returns>A <see cref="Task"/></returns>
         public async Task Push<TMessage>(string messageQueue, IEnumerable<TMessage> messages, ExchangeType exchangeType = ExchangeType.Default, CancellationToken cancellationToken = default)
         {
@@ -255,17 +265,22 @@ namespace CDP4ServicesMessaging.Services.Messaging
             try
             {
                 var channel = await this.GetChannelAsync(cancellationToken);
-                this.EnsureQueueAndExchangeAreDeclared(messageQueue, channel, exchangeType, true);
+                await this.EnsureQueueAndExchangeAreDeclaredAsync(messageQueue, channel, exchangeType, isPush: true, cancellationToken: cancellationToken);
 
-                var properties = channel.CreateBasicProperties();
-                properties.Type = typeof(TMessage).Name;
-                properties.DeliveryMode = 2;
-                properties.ContentType = "application/json";
+                var properties = new BasicProperties
+                {
+                    Type = typeof(TMessage).Name,
+                    DeliveryMode = DeliveryModes.Persistent,
+                    ContentType = "application/json"
+                };
 
-                channel.BasicPublish(exchange: exchangeType is ExchangeType.Fanout ? messageQueue : "",
+                await channel.BasicPublishAsync(
+                    exchange: exchangeType is ExchangeType.Fanout ? messageQueue : "",
                     routingKey: messageQueue,
+                    mandatory: false,
                     basicProperties: properties,
-                    body: this.Serializer.Serialize(message));
+                    body: this.Serializer.Serialize(message),
+                    cancellationToken: cancellationToken);
 
                 this.Logger.LogInformation("Message {MessageName} sent to {MessageQueue}", typeof(TMessage).Name, messageQueue);
             }
@@ -293,27 +308,29 @@ namespace CDP4ServicesMessaging.Services.Messaging
         /// Declares the message queue if not declared yet
         /// </summary>
         /// <param name="messageQueue">The queue identifier</param>
-        /// <param name="channel">The <see cref="IModel"/> channel on which to declare the queue</param>
+        /// <param name="channel">The <see cref="IChannel"/> on which to declare the queue</param>
         /// <param name="exchangeType">The string exchange type It can be any value from <see cref="ExchangeType"/>, default value is <see cref="ExchangeType.Default"/></param>
         /// <param name="isPush">A value indicating whether the queue and exchange will be used for pushing messages</param>
+        /// <param name="cancellationToken">A possible <see cref="CancellationToken"/></param>
         /// <returns>The queue name</returns>
-        private string EnsureQueueAndExchangeAreDeclared(string messageQueue, IModel channel, ExchangeType exchangeType, bool isPush = false)
+        private async Task<string> EnsureQueueAndExchangeAreDeclaredAsync(string messageQueue, IChannel channel, ExchangeType exchangeType, bool isPush = false, CancellationToken cancellationToken = default)
         {
             if (exchangeType is ExchangeType.Fanout)
             {
-                channel.ExchangeDeclare(exchange: messageQueue, type: exchangeType.ToString().ToLower(), true);
+                await channel.ExchangeDeclareAsync(exchange: messageQueue, type: exchangeType.ToString().ToLower(), durable: true, autoDelete: false, arguments: null, cancellationToken: cancellationToken);
 
                 if (isPush)
                 {
                     return messageQueue;
                 }
 
-                var queueName = channel.QueueDeclare().QueueName;
-                channel.QueueBind(queueName, messageQueue, messageQueue);
+                var declareOk = await channel.QueueDeclareAsync(queue: string.Empty, durable: false, exclusive: true, autoDelete: true, arguments: null, cancellationToken: cancellationToken);
+                var queueName = declareOk.QueueName;
+                await channel.QueueBindAsync(queueName, messageQueue, messageQueue, arguments: null, cancellationToken: cancellationToken);
                 return queueName;
             }
 
-            channel.QueueDeclare(queue: messageQueue, durable: false, exclusive: false, autoDelete: false, arguments: null);
+            await channel.QueueDeclareAsync(queue: messageQueue, durable: false, exclusive: false, autoDelete: false, arguments: null, cancellationToken: cancellationToken);
             return messageQueue;
         }
     }

--- a/CDP4ServicesMessaging/Services/ThingMessaging/ThingMessageConsumer.cs
+++ b/CDP4ServicesMessaging/Services/ThingMessaging/ThingMessageConsumer.cs
@@ -37,6 +37,8 @@ namespace CDP4ServicesMessaging.Services.ThingMessaging
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
+    using RabbitMQ.Client.Events;
+
     /// <summary>
     /// The <see cref="ThingMessageConsumer"/> provides consumers for <see cref="ThingsChangedMessage"/>.
     /// </summary>
@@ -70,11 +72,12 @@ namespace CDP4ServicesMessaging.Services.ThingMessaging
         /// <return>A <see cref="Task"/> of <see cref="IDisposable"/></return>
         public async Task<IDisposable> AddListener(Action<ThingsChangedMessage> onReceive, CancellationToken cancellationToken = default)
         {
-            return await this.AddListener(nameof(ThingsChangedMessage), (_, m) =>
+            return await this.AddListener(nameof(ThingsChangedMessage), (AsyncEventHandler<BasicDeliverEventArgs>)((_, m) =>
             {
                 var thingsChangedMessage = this.Serializer.Deserialize<ThingsChangedMessage>(m.Body);
                 onReceive(thingsChangedMessage);
-            }, ExchangeType.Fanout, cancellationToken);
+                return Task.CompletedTask;
+            }), ExchangeType.Fanout, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Necessary public-API break: IMessageClientService.AddListener now takes AsyncEventHandler<BasicDeliverEventArgs> instead of EventHandler<...> —  the 7.x AsyncEventingBasicConsumer cannot accept synchronous delegates.
  Functional behaviour (Polly retry, fanout vs default routing, persistent delivery mode) is unchanged.


<!-- Thanks for contributing to COMET-SDK! -->