### PR TITLE
 [Add] net10.0 as a target framework to all 12 library projects

### DIFF
--- a/CDP4Common/CDP4Common.csproj
+++ b/CDP4Common/CDP4Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4Common Community Edition</Title>
         <VersionPrefix>30.0.1</VersionPrefix>
@@ -25,7 +25,7 @@
         <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
         <LangVersion>latest</LangVersion>
         <PackageReleaseNotes>
-            [Bump] Version to 30.0.1
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
     </PropertyGroup>
 

--- a/CDP4Common/Extensions/IEnumerableExtensions.cs
+++ b/CDP4Common/Extensions/IEnumerableExtensions.cs
@@ -33,10 +33,11 @@ namespace CDP4Common.Extensions
     /// </summary>
     public static class IEnumerableExtensions
     {
+#if !NET
         /// <summary>
         /// Returns all distinct elements of the given source, where "distinctness"
         /// is determined via a projection and the default equality comparer for the projected type.
-        /// </summary>        
+        /// </summary>
         /// <typeparam name="TSource">Type of the source sequence</typeparam>
         /// <typeparam name="TKey">Type of the projected element</typeparam>
         /// <param name="source">Source sequence</param>
@@ -57,6 +58,7 @@ namespace CDP4Common.Extensions
                 }
             }
         }
+#endif
 
         /// <summary>
         /// Checks wether a <see cref="IEnumerable{T}"/> is null or does not contains any items

--- a/CDP4Common/Polyfills/TypePolyfills.cs
+++ b/CDP4Common/Polyfills/TypePolyfills.cs
@@ -27,7 +27,7 @@ namespace CDP4Common.Polyfills
     using System;
     using System.Reflection;
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NET
 
     /// <summary>
     /// The purpose of the <see cref="TypePolyfills"/> class is to provide extension methods on the <see cref="Type"/>

--- a/CDP4Dal/CDP4Dal.csproj
+++ b/CDP4Dal/CDP4Dal.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4Dal Community Edition</Title>
         <VersionPrefix>30.0.1</VersionPrefix>
@@ -21,8 +21,7 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Revert] Breaking changes (ConfigureAwait(false))
-            [Update] CDP4DalCommon to version 30.0.1.
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>latest</LangVersion>

--- a/CDP4DalCommon/CDP4DalCommon.csproj
+++ b/CDP4DalCommon/CDP4DalCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
       <Company>Starion Group S.A.</Company>
       <Language>latest</Language>
       <Title>CDP4DalCommon Community Edition</Title>
@@ -21,7 +21,7 @@
       <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
       <GenerateSBOM>true</GenerateSBOM>
       <PackageReleaseNotes>
-          [Update] CDP4Common to version 30.0.1.
+          [Add] net10.0 as a Target Framework
       </PackageReleaseNotes>
       <PackageReadmeFile>README.md</PackageReadmeFile>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/CDP4JsonFileDal/CDP4JsonFileDal.csproj
+++ b/CDP4JsonFileDal/CDP4JsonFileDal.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4JsonFileDal Community Edition</Title>
         <VersionPrefix>30.0.1</VersionPrefix>
@@ -21,8 +21,7 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Update] CDP4JsonSerializer to version 30.0.1.
-            [Update] CDP4Dal to version 30.0.1.
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>latest</LangVersion>

--- a/CDP4JsonSerializer/CDP4JsonSerializer.csproj
+++ b/CDP4JsonSerializer/CDP4JsonSerializer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4JsonSerializer Community Edition</Title>
         <VersionPrefix>30.0.1</VersionPrefix>
@@ -21,7 +21,7 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Update] CDP4DalCommon to version 30.0.1.
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>latest</LangVersion>

--- a/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
+++ b/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4MessagePackSerializer Community Edition</Title>
         <VersionPrefix>30.0.1</VersionPrefix>
@@ -21,7 +21,7 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Update] CDP4Common to version 30.0.1.
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>latest</LangVersion>

--- a/CDP4Reporting/CDP4Reporting.csproj
+++ b/CDP4Reporting/CDP4Reporting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4Reporting Community Edition</Title>
         <VersionPrefix>30.0.1</VersionPrefix>
@@ -21,8 +21,7 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Update] CDP4Dal to version 30.0.1.
-            [Update] CDP4JsonSerializer to version 30.0.1.
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
         <LangVersion>latest</LangVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
+++ b/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4RequirementsVerification Community Edition</Title>
         <VersionPrefix>30.0.1</VersionPrefix>
@@ -20,7 +20,7 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Update] CDP4Dal to version 30.0.1.
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>latest</LangVersion>

--- a/CDP4Rules/CDP4Rules.csproj
+++ b/CDP4Rules/CDP4Rules.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4Rules Community Edition</Title>
         <VersionPrefix>30.0.1</VersionPrefix>
@@ -20,7 +20,7 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Update] CDP4Common to version 30.0.1.
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>latest</LangVersion>

--- a/CDP4ServicesDal/CDP4ServicesDal.csproj
+++ b/CDP4ServicesDal/CDP4ServicesDal.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4ServicesDal Community Edition</Title>
         <VersionPrefix>30.0.1</VersionPrefix>
@@ -20,10 +20,7 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Revert] Breaking changes (ConfigureAwait(false))
-            [Update] CDP4JsonSerializer to version 30.0.1.
-            [Update] CDP4MessagePackSerializer to version 30.0.1.
-            [Update] CDP4Dal to version 30.0.1.
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>latest</LangVersion>

--- a/CDP4ServicesMessaging/CDP4ServicesMessaging.csproj
+++ b/CDP4ServicesMessaging/CDP4ServicesMessaging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4Common Community Edition</Title>
         <VersionPrefix>30.0.1</VersionPrefix>
@@ -21,8 +21,7 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Update] CDP4Dal to version 30.0.1.
-            [Update] CDP4JsonSerializer to version 30.0.1.
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>latest</LangVersion>

--- a/CDP4Web/CDP4Web.csproj
+++ b/CDP4Web/CDP4Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4Web Community Edition</Title>
@@ -21,7 +21,7 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Update] CDP4ServicesDal to version 30.0.1.
+            [Add] net10.0 as a Target Framework
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

- Added `net10.0` to `<TargetFrameworks>` in all 12 library projects. The 10 projects that were `net48;netstandard2.0` become
  `net48;netstandard2.0;net10.0`; `CDP4ServicesMessaging` and `CDP4Web` move from `netstandard2.0` to `netstandard2.0;net10.0`. Existing `net48`
  and `netstandard2.0` consumers are unaffected.
- `CDP4Common\Polyfills\TypePolyfills.cs`: `#if NETFRAMEWORK` → `#if NETFRAMEWORK || NET` so net10 uses direct `Type.Assembly` /  `Type.IsValueType` instead of the `GetTypeInfo()` shim — relevant for the MetaInfo / `PocoThingFactory` reflection hot path.
- `CDP4Common\Extensions\IEnumerableExtensions.cs`: wrapped the `DistinctBy` polyfill in `#if !NET` to resolve `CS0121` ambiguity with the in-box  `System.Linq.Enumerable.DistinctBy` on net10.
- `<PackageReleaseNotes>` reset to `[Add] net10.0 as a Target Framework` across all 12 library csproj files.
- The 22 `#if NETFRAMEWORK` MEF blocks already correctly route net10 through the `#else` (no-MEF, plain DI) branch — same contract as the existing netstandard2.0 path. No changes required.

  ## Why
Net10 consumers (including this SDK's own `*.NetCore.Tests` projects) currently load the `netstandard2.0` build via compatibility shims and pull polyfilled NuGet packages instead of the in-box BCL. A native `net10.0` TFM gives them in-box `System.Text.Json` (with hardware-intrinsic UTF-8 in `Utf8JsonReader`/`Writer`), faster `Span<T>`, optimized ConcurrentDictionary` (used heavily in `Assembler`), and dynamic PGO over the DTO ↔ POCO conversion pipeline. Purely additive — no breaking changes.



<!-- Thanks for contributing to COMET-SDK! -->